### PR TITLE
Feature/wrapper plugin

### DIFF
--- a/backend-migration/README.md
+++ b/backend-migration/README.md
@@ -99,6 +99,18 @@ Example: disable debug endpoints while keeping metadata and system endpoints:
 COMET_RS_INCLUDE_DEBUG_ENDPOINTS=0 uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 ```
 
+Example: disable system endpoints (`/api/health`, `/api/platforms`) while keeping metadata + debug:
+
+```bash
+COMET_RS_INCLUDE_SYSTEM_ENDPOINTS=0 uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+Example: disable metadata endpoints while keeping system + debug endpoint groups:
+
+```bash
+COMET_RS_INCLUDE_METADATA_ENDPOINTS=0 uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+```
+
 ## Documentation
 
 - **[DEVELOPER_GUIDE.md](./docs/DEVELOPER_GUIDE.md)** - Complete guide explaining the codebase, architecture, and how everything works. Perfect for new developers!

--- a/backend-migration/README.md
+++ b/backend-migration/README.md
@@ -84,6 +84,21 @@ Pipeline runtime is enabled by default. To force legacy runtime during rollback/
 COMET_RS_USE_PIPELINE_RUNTIME=0 uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 ```
 
+### Endpoint Registration Controls
+
+Default endpoint groups are registered via the framework endpoint registry. You can
+toggle endpoint groups per deployment using environment variables:
+
+- `COMET_RS_INCLUDE_METADATA_ENDPOINTS` (default: `true`)
+- `COMET_RS_INCLUDE_DEBUG_ENDPOINTS` (default: `true`)
+- `COMET_RS_INCLUDE_SYSTEM_ENDPOINTS` (default: `true`)
+
+Example: disable debug endpoints while keeping metadata and system endpoints:
+
+```bash
+COMET_RS_INCLUDE_DEBUG_ENDPOINTS=0 uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+```
+
 ## Documentation
 
 - **[DEVELOPER_GUIDE.md](./docs/DEVELOPER_GUIDE.md)** - Complete guide explaining the codebase, architecture, and how everything works. Perfect for new developers!

--- a/backend-migration/README.md
+++ b/backend-migration/README.md
@@ -64,6 +64,26 @@ To test the migration:
    curl "http://localhost:8000/api/v1/metadata?repo_url={URL}"
    ```
 
+### Pipeline Migration Parity Checks
+
+Use the parity utility to compare legacy extraction vs framework pipeline extraction:
+
+```bash
+python scripts/check_pipeline_parity.py "https://github.com/psf/requests" --schema maSMP --with-enrichment
+```
+
+For full diagnostics (including full payloads), add `--json`:
+
+```bash
+python scripts/check_pipeline_parity.py "https://github.com/psf/requests" --schema maSMP --with-enrichment --json
+```
+
+Opt in to the new pipeline runtime path (default is legacy path):
+
+```bash
+COMET_RS_USE_PIPELINE_RUNTIME=1 uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+```
+
 ## Documentation
 
 - **[DEVELOPER_GUIDE.md](./docs/DEVELOPER_GUIDE.md)** - Complete guide explaining the codebase, architecture, and how everything works. Perfect for new developers!

--- a/backend-migration/README.md
+++ b/backend-migration/README.md
@@ -78,10 +78,10 @@ For full diagnostics (including full payloads), add `--json`:
 python scripts/check_pipeline_parity.py "https://github.com/psf/requests" --schema maSMP --with-enrichment --json
 ```
 
-Opt in to the new pipeline runtime path (default is legacy path):
+Pipeline runtime is enabled by default. To force legacy runtime during rollback/testing:
 
 ```bash
-COMET_RS_USE_PIPELINE_RUNTIME=1 uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+COMET_RS_USE_PIPELINE_RUNTIME=0 uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 ```
 
 ## Documentation

--- a/backend-migration/app/api/endpoints/metadata.py
+++ b/backend-migration/app/api/endpoints/metadata.py
@@ -4,7 +4,6 @@ Schemas in api/schemas; composition in api/services.
 """
 import asyncio
 import json
-import os
 import queue
 from typing import Optional
 
@@ -20,7 +19,6 @@ from app.api.schemas.metadata import (
 )
 from app.api.services import fairness_service
 from app.api.services.metadata_service import (
-    compare_legacy_and_pipeline_extraction,
     run_extraction,
     run_extraction_with_progress,
     run_single_property_extraction,
@@ -33,11 +31,6 @@ STEP_LABELS = {step_id: label for step_id, label in EXTRACTION_STEPS}
 
 
 router = APIRouter(prefix="/api", tags=["Metadata"])
-
-
-def _parity_endpoint_enabled() -> bool:
-    raw = os.getenv("COMET_RS_ENABLE_PARITY_ENDPOINT", "0").strip().lower()
-    return raw in {"1", "true", "yes", "on"}
 
 
 @router.get("/metadata", response_model=MetadataPlainResponse)
@@ -404,45 +397,3 @@ async def get_supported_platforms():
             {"name": "GitLab", "url_pattern": "gitlab.com", "description": "GitLab repositories"},
         ]
     }
-
-
-@router.get("/debug/pipeline-parity")
-async def debug_pipeline_parity(
-    repo_url: HttpUrl = Query(
-        ...,
-        description="URL of the code repository (GitHub, GitLab)",
-    ),
-    schema: str = Query(
-        "maSMP",
-        description="Schema to analyze against",
-        enum=["maSMP", "CODEMETA"],
-    ),
-    access_token: Optional[str] = Query(
-        None,
-        description="Optional access token for private repositories",
-    ),
-    with_enrichment: bool = Query(
-        False,
-        description="Whether to compare enriched metadata parity as well",
-    ),
-):
-    """
-    Debug-only endpoint to compare legacy and pipeline extraction parity.
-
-    Guarded by COMET_RS_ENABLE_PARITY_ENDPOINT and disabled by default.
-    """
-    if not _parity_endpoint_enabled():
-        raise HTTPException(status_code=404, detail="Not found")
-
-    try:
-        parity = compare_legacy_and_pipeline_extraction(
-            repo_url=str(repo_url),
-            schema=schema,
-            access_token=access_token,
-            with_enrichment=with_enrichment,
-        )
-        return {"status": "success", "parity": parity}
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")

--- a/backend-migration/app/api/endpoints/metadata.py
+++ b/backend-migration/app/api/endpoints/metadata.py
@@ -4,6 +4,7 @@ Schemas in api/schemas; composition in api/services.
 """
 import asyncio
 import json
+import os
 import queue
 from typing import Optional
 
@@ -19,6 +20,7 @@ from app.api.schemas.metadata import (
 )
 from app.api.services import fairness_service
 from app.api.services.metadata_service import (
+    compare_legacy_and_pipeline_extraction,
     run_extraction,
     run_extraction_with_progress,
     run_single_property_extraction,
@@ -31,6 +33,11 @@ STEP_LABELS = {step_id: label for step_id, label in EXTRACTION_STEPS}
 
 
 router = APIRouter(prefix="/api", tags=["Metadata"])
+
+
+def _parity_endpoint_enabled() -> bool:
+    raw = os.getenv("COMET_RS_ENABLE_PARITY_ENDPOINT", "0").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
 
 
 @router.get("/metadata", response_model=MetadataPlainResponse)
@@ -397,3 +404,45 @@ async def get_supported_platforms():
             {"name": "GitLab", "url_pattern": "gitlab.com", "description": "GitLab repositories"},
         ]
     }
+
+
+@router.get("/debug/pipeline-parity")
+async def debug_pipeline_parity(
+    repo_url: HttpUrl = Query(
+        ...,
+        description="URL of the code repository (GitHub, GitLab)",
+    ),
+    schema: str = Query(
+        "maSMP",
+        description="Schema to analyze against",
+        enum=["maSMP", "CODEMETA"],
+    ),
+    access_token: Optional[str] = Query(
+        None,
+        description="Optional access token for private repositories",
+    ),
+    with_enrichment: bool = Query(
+        False,
+        description="Whether to compare enriched metadata parity as well",
+    ),
+):
+    """
+    Debug-only endpoint to compare legacy and pipeline extraction parity.
+
+    Guarded by COMET_RS_ENABLE_PARITY_ENDPOINT and disabled by default.
+    """
+    if not _parity_endpoint_enabled():
+        raise HTTPException(status_code=404, detail="Not found")
+
+    try:
+        parity = compare_legacy_and_pipeline_extraction(
+            repo_url=str(repo_url),
+            schema=schema,
+            access_token=access_token,
+            with_enrichment=with_enrichment,
+        )
+        return {"status": "success", "parity": parity}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")

--- a/backend-migration/app/api/endpoints/metadata.py
+++ b/backend-migration/app/api/endpoints/metadata.py
@@ -382,18 +382,3 @@ async def extract_single_property(
         raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")
 
 
-@router.get("/health")
-async def health_check():
-    """Health check endpoint."""
-    return {"status": "healthy", "service": "metadata-extractor"}
-
-
-@router.get("/platforms")
-async def get_supported_platforms():
-    """Get list of supported platforms."""
-    return {
-        "platforms": [
-            {"name": "GitHub", "url_pattern": "github.com", "description": "GitHub repositories"},
-            {"name": "GitLab", "url_pattern": "gitlab.com", "description": "GitLab repositories"},
-        ]
-    }

--- a/backend-migration/app/api/services/metadata_service.py
+++ b/backend-migration/app/api/services/metadata_service.py
@@ -5,6 +5,7 @@ Routes existing API calls into the new framework runtime layer.
 from typing import Optional, Dict, Any, Callable, List
 
 from app.framework.api.metadata_runtime import (
+    compare_legacy_and_pipeline_extraction as _framework_compare_legacy_and_pipeline_extraction,
     create_extraction_use_case as _framework_create_extraction_use_case,
     run_extraction as _framework_run_extraction,
     run_extraction_with_progress as _framework_run_extraction_with_progress,
@@ -88,4 +89,19 @@ def run_single_property_extraction(
         schema=schema,
         access_token=access_token,
         property_name=property_name,
+    )
+
+
+def compare_legacy_and_pipeline_extraction(
+    repo_url: str,
+    schema: str,
+    access_token: Optional[str],
+    with_enrichment: bool,
+) -> Dict[str, Any]:
+    """Compare legacy and pipeline runtime outputs for migration parity checks."""
+    return _framework_compare_legacy_and_pipeline_extraction(
+        repo_url=repo_url,
+        schema=schema,
+        access_token=access_token,
+        with_enrichment=with_enrichment,
     )

--- a/backend-migration/app/api/services/metadata_service.py
+++ b/backend-migration/app/api/services/metadata_service.py
@@ -1,58 +1,28 @@
 """
-Metadata extraction service: wires adapters and use case, runs extraction.
-Single place for composition; endpoints call this instead of building the use case themselves.
+Compatibility service entrypoints for metadata extraction.
+Routes existing API calls into the new framework runtime layer.
 """
-from datetime import datetime
 from typing import Optional, Dict, Any, Callable, List
 
-from app.domain.services.url_pattern_matcher import URLPatternMatcher
-from app.adapters.factory import PlatformExtractorFactory
-from app.adapters.file_parser_adapter import FileParserAdapter
-from app.adapters.external_data_fetcher_adapter import ExternalDataFetcherAdapter
-from app.adapters.jsonld_builder import JSONLDBuilder
-from app.adapters.extraction_metadata_collector import InMemoryExtractionMetadataCollector
-from app.domain.services.llm_extractor import LLMExtractor
-from app.application.use_cases.extract_metadata import ExtractMetadataUseCase
-from app.api.builders.enriched_metadata import build_enriched_metadata
-
-
-# Stateless components (created once, reused)
-_llm_extractor = LLMExtractor()
-_jsonld_builder = JSONLDBuilder()
+from app.framework.api.metadata_runtime import (
+    create_extraction_use_case as _framework_create_extraction_use_case,
+    run_extraction as _framework_run_extraction,
+    run_extraction_with_progress as _framework_run_extraction_with_progress,
+    run_single_property_extraction as _framework_run_single_property_extraction,
+)
 
 
 def _create_extraction_use_case(
     repo_url: str,
     access_token: Optional[str],
     with_enrichment: bool,
-) -> tuple[ExtractMetadataUseCase, Optional[InMemoryExtractionMetadataCollector]]:
-    """
-    Internal helper to create a fully-wired ExtractMetadataUseCase plus optional collector.
-
-    This centralises the orchestration wiring so that different services
-    (plain extraction, extraction with progress, FAIRness assessment, etc.)
-    can all share the same composition.
-    """
-    url_matcher = URLPatternMatcher()
-    platform = url_matcher.detect_platform(repo_url)
-    if not platform:
-        raise ValueError("Unsupported repository platform. Supported: GitHub, GitLab")
-
-    platform_extractor = PlatformExtractorFactory.create_extractor(repo_url, access_token)
-    file_parser = FileParserAdapter(platform, access_token)
-    external_data_fetcher = ExternalDataFetcherAdapter(platform, access_token)
-    collector = InMemoryExtractionMetadataCollector() if with_enrichment else None
-
-    use_case = ExtractMetadataUseCase(
-        platform_extractor=platform_extractor,
-        file_parser=file_parser,
-        external_data_fetcher=external_data_fetcher,
-        llm_extractor=_llm_extractor,
-        jsonld_builder=_jsonld_builder,
-        extraction_metadata_collector=collector,
+):
+    """Legacy helper retained for compatibility during migration."""
+    return _framework_create_extraction_use_case(
+        repo_url=repo_url,
+        access_token=access_token,
+        with_enrichment=with_enrichment,
     )
-
-    return use_case, collector
 
 
 def run_extraction(
@@ -67,23 +37,12 @@ def run_extraction(
     Returns:
         (jsonld_document, enriched_metadata or None)
     """
-    use_case, collector = _create_extraction_use_case(
+    return _framework_run_extraction(
         repo_url=repo_url,
+        schema=schema,
         access_token=access_token,
         with_enrichment=with_enrichment,
     )
-
-    result = use_case.execute(repo_url=repo_url, schema=schema, access_token=access_token)
-    jsonld_document = result.jsonld_document
-
-    if with_enrichment and result.extraction_metadata:
-        enriched = build_enriched_metadata(
-            jsonld_document,
-            result.extraction_metadata,
-            schema,
-        )
-        return jsonld_document, enriched
-    return jsonld_document, None
 
 
 def run_extraction_with_progress(
@@ -102,28 +61,13 @@ def run_extraction_with_progress(
     Returns:
         (jsonld_document, enriched_metadata or None)
     """
-    use_case, collector = _create_extraction_use_case(
-        repo_url=repo_url,
-        access_token=access_token,
-        with_enrichment=with_enrichment,
-    )
-
-    result = use_case.execute(
+    return _framework_run_extraction_with_progress(
         repo_url=repo_url,
         schema=schema,
         access_token=access_token,
+        with_enrichment=with_enrichment,
         progress_callback=progress_callback,
     )
-    jsonld_document = result.jsonld_document
-
-    if with_enrichment and result.extraction_metadata:
-        enriched = build_enriched_metadata(
-            jsonld_document,
-            result.extraction_metadata,
-            schema,
-        )
-        return jsonld_document, enriched
-    return jsonld_document, None
 
 
 def run_single_property_extraction(
@@ -139,50 +83,9 @@ def run_single_property_extraction(
     Returns:
         (extracted_at_iso, [ {profile, value, source, confidence}, ... ])
     """
-    jsonld_document, enriched = run_extraction(
+    return _framework_run_single_property_extraction(
         repo_url=repo_url,
         schema=schema,
         access_token=access_token,
-        with_enrichment=True,
+        property_name=property_name,
     )
-
-    extracted_at = datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
-    results: List[Dict[str, Any]] = []
-
-    enriched = enriched or {}
-
-    if schema == "CODEMETA":
-        value = jsonld_document.get(property_name)
-        profile_key = "codemeta"
-        profile_meta = enriched.get(profile_key, {})
-        record = profile_meta.get(property_name, {})
-        results.append(
-            {
-                "profile": profile_key,
-                "value": value,
-                "source": record.get("source"),
-                "confidence": record.get("confidence"),
-            }
-        )
-        return extracted_at, results
-
-    # maSMP profiles – property may appear in SoftwareSourceCode and/or SoftwareApplication
-    for profile_key in ("maSMP:SoftwareSourceCode", "maSMP:SoftwareApplication"):
-        profile_data = jsonld_document.get(profile_key)
-        if not isinstance(profile_data, dict):
-            continue
-        if property_name not in profile_data:
-            continue
-        value = profile_data.get(property_name)
-        profile_meta = enriched.get(profile_key, {})
-        record = profile_meta.get(property_name, {})
-        results.append(
-            {
-                "profile": profile_key,
-                "value": value,
-                "source": record.get("source"),
-                "confidence": record.get("confidence"),
-            }
-        )
-
-    return extracted_at, results

--- a/backend-migration/app/framework/__init__.py
+++ b/backend-migration/app/framework/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable framework package for extraction architecture."""

--- a/backend-migration/app/framework/api/__init__.py
+++ b/backend-migration/app/framework/api/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable API endpoint wiring layer."""

--- a/backend-migration/app/framework/api/__init__.py
+++ b/backend-migration/app/framework/api/__init__.py
@@ -1,5 +1,11 @@
 """Reusable API endpoint wiring layer."""
 
 from app.framework.api.public import assess_fairness, extract_metadata, extract_property
+from app.framework.api.endpoint_registry import register_default_endpoints
 
-__all__ = ["extract_metadata", "extract_property", "assess_fairness"]
+__all__ = [
+    "extract_metadata",
+    "extract_property",
+    "assess_fairness",
+    "register_default_endpoints",
+]

--- a/backend-migration/app/framework/api/__init__.py
+++ b/backend-migration/app/framework/api/__init__.py
@@ -1,6 +1,7 @@
 """Reusable API endpoint wiring layer."""
 
 from app.framework.api.public import assess_fairness, extract_metadata, extract_property
+from app.framework.api.endpoint_config import EndpointRegistrationConfig
 from app.framework.api.endpoint_registry import register_default_endpoints
 from app.framework.api.metadata_router import create_metadata_router
 from app.framework.api.debug_router import create_debug_router
@@ -10,6 +11,7 @@ __all__ = [
     "extract_metadata",
     "extract_property",
     "assess_fairness",
+    "EndpointRegistrationConfig",
     "register_default_endpoints",
     "create_metadata_router",
     "create_debug_router",

--- a/backend-migration/app/framework/api/__init__.py
+++ b/backend-migration/app/framework/api/__init__.py
@@ -1,1 +1,5 @@
 """Reusable API endpoint wiring layer."""
+
+from app.framework.api.public import assess_fairness, extract_metadata, extract_property
+
+__all__ = ["extract_metadata", "extract_property", "assess_fairness"]

--- a/backend-migration/app/framework/api/__init__.py
+++ b/backend-migration/app/framework/api/__init__.py
@@ -2,10 +2,16 @@
 
 from app.framework.api.public import assess_fairness, extract_metadata, extract_property
 from app.framework.api.endpoint_registry import register_default_endpoints
+from app.framework.api.metadata_router import create_metadata_router
+from app.framework.api.debug_router import create_debug_router
+from app.framework.api.system_router import create_system_router
 
 __all__ = [
     "extract_metadata",
     "extract_property",
     "assess_fairness",
     "register_default_endpoints",
+    "create_metadata_router",
+    "create_debug_router",
+    "create_system_router",
 ]

--- a/backend-migration/app/framework/api/debug_router.py
+++ b/backend-migration/app/framework/api/debug_router.py
@@ -1,0 +1,62 @@
+"""Framework-level debug router factory."""
+
+import os
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import HttpUrl
+
+from app.api.services.metadata_service import compare_legacy_and_pipeline_extraction
+
+
+def _parity_endpoint_enabled() -> bool:
+    raw = os.getenv("COMET_RS_ENABLE_PARITY_ENDPOINT", "0").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def create_debug_router() -> APIRouter:
+    """Create debug router for migration/parity endpoints."""
+    router = APIRouter(prefix="/api", tags=["Metadata"])
+
+    @router.get("/debug/pipeline-parity")
+    async def debug_pipeline_parity(
+        repo_url: HttpUrl = Query(
+            ...,
+            description="URL of the code repository (GitHub, GitLab)",
+        ),
+        schema: str = Query(
+            "maSMP",
+            description="Schema to analyze against",
+            enum=["maSMP", "CODEMETA"],
+        ),
+        access_token: Optional[str] = Query(
+            None,
+            description="Optional access token for private repositories",
+        ),
+        with_enrichment: bool = Query(
+            False,
+            description="Whether to compare enriched metadata parity as well",
+        ),
+    ):
+        """
+        Debug-only endpoint to compare legacy and pipeline extraction parity.
+
+        Guarded by COMET_RS_ENABLE_PARITY_ENDPOINT and disabled by default.
+        """
+        if not _parity_endpoint_enabled():
+            raise HTTPException(status_code=404, detail="Not found")
+
+        try:
+            parity = compare_legacy_and_pipeline_extraction(
+                repo_url=str(repo_url),
+                schema=schema,
+                access_token=access_token,
+                with_enrichment=with_enrichment,
+            )
+            return {"status": "success", "parity": parity}
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")
+
+    return router

--- a/backend-migration/app/framework/api/endpoint_config.py
+++ b/backend-migration/app/framework/api/endpoint_config.py
@@ -1,0 +1,12 @@
+"""Configuration for framework endpoint registration."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class EndpointRegistrationConfig:
+    """Controls which default endpoint groups are registered."""
+
+    include_metadata: bool = True
+    include_debug: bool = True
+    include_system: bool = True

--- a/backend-migration/app/framework/api/endpoint_config.py
+++ b/backend-migration/app/framework/api/endpoint_config.py
@@ -1,6 +1,14 @@
 """Configuration for framework endpoint registration."""
 
 from dataclasses import dataclass
+import os
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
 @dataclass(frozen=True)
@@ -10,3 +18,12 @@ class EndpointRegistrationConfig:
     include_metadata: bool = True
     include_debug: bool = True
     include_system: bool = True
+
+    @classmethod
+    def from_env(cls) -> "EndpointRegistrationConfig":
+        """Create endpoint registration config from environment variables."""
+        return cls(
+            include_metadata=_env_bool("COMET_RS_INCLUDE_METADATA_ENDPOINTS", True),
+            include_debug=_env_bool("COMET_RS_INCLUDE_DEBUG_ENDPOINTS", True),
+            include_system=_env_bool("COMET_RS_INCLUDE_SYSTEM_ENDPOINTS", True),
+        )

--- a/backend-migration/app/framework/api/endpoint_registry.py
+++ b/backend-migration/app/framework/api/endpoint_registry.py
@@ -1,0 +1,15 @@
+"""Reusable API endpoint registration helpers."""
+
+from fastapi import FastAPI
+
+from app.api.endpoints import metadata
+
+
+def register_default_endpoints(app: FastAPI) -> None:
+    """
+    Register the default API endpoint set.
+
+    This is the first framework-level registrar entrypoint and preserves
+    the existing endpoint contract by wiring the current metadata router.
+    """
+    app.include_router(metadata.router)

--- a/backend-migration/app/framework/api/endpoint_registry.py
+++ b/backend-migration/app/framework/api/endpoint_registry.py
@@ -3,17 +3,25 @@
 from fastapi import FastAPI
 
 from app.framework.api.debug_router import create_debug_router
+from app.framework.api.endpoint_config import EndpointRegistrationConfig
 from app.framework.api.metadata_router import create_metadata_router
 from app.framework.api.system_router import create_system_router
 
 
-def register_default_endpoints(app: FastAPI) -> None:
+def register_default_endpoints(
+    app: FastAPI,
+    config: EndpointRegistrationConfig | None = None,
+) -> None:
     """
     Register the default API endpoint set.
 
     This is the first framework-level registrar entrypoint and preserves
     the existing endpoint contract by wiring the current metadata router.
     """
-    app.include_router(create_metadata_router())
-    app.include_router(create_debug_router())
-    app.include_router(create_system_router())
+    config = config or EndpointRegistrationConfig()
+    if config.include_metadata:
+        app.include_router(create_metadata_router())
+    if config.include_debug:
+        app.include_router(create_debug_router())
+    if config.include_system:
+        app.include_router(create_system_router())

--- a/backend-migration/app/framework/api/endpoint_registry.py
+++ b/backend-migration/app/framework/api/endpoint_registry.py
@@ -3,6 +3,7 @@
 from fastapi import FastAPI
 
 from app.api.endpoints import metadata
+from app.framework.api.debug_router import create_debug_router
 
 
 def register_default_endpoints(app: FastAPI) -> None:
@@ -13,3 +14,4 @@ def register_default_endpoints(app: FastAPI) -> None:
     the existing endpoint contract by wiring the current metadata router.
     """
     app.include_router(metadata.router)
+    app.include_router(create_debug_router())

--- a/backend-migration/app/framework/api/endpoint_registry.py
+++ b/backend-migration/app/framework/api/endpoint_registry.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 
 from app.api.endpoints import metadata
 from app.framework.api.debug_router import create_debug_router
+from app.framework.api.system_router import create_system_router
 
 
 def register_default_endpoints(app: FastAPI) -> None:
@@ -15,3 +16,4 @@ def register_default_endpoints(app: FastAPI) -> None:
     """
     app.include_router(metadata.router)
     app.include_router(create_debug_router())
+    app.include_router(create_system_router())

--- a/backend-migration/app/framework/api/endpoint_registry.py
+++ b/backend-migration/app/framework/api/endpoint_registry.py
@@ -2,8 +2,8 @@
 
 from fastapi import FastAPI
 
-from app.api.endpoints import metadata
 from app.framework.api.debug_router import create_debug_router
+from app.framework.api.metadata_router import create_metadata_router
 from app.framework.api.system_router import create_system_router
 
 
@@ -14,6 +14,6 @@ def register_default_endpoints(app: FastAPI) -> None:
     This is the first framework-level registrar entrypoint and preserves
     the existing endpoint contract by wiring the current metadata router.
     """
-    app.include_router(metadata.router)
+    app.include_router(create_metadata_router())
     app.include_router(create_debug_router())
     app.include_router(create_system_router())

--- a/backend-migration/app/framework/api/metadata_router.py
+++ b/backend-migration/app/framework/api/metadata_router.py
@@ -1,0 +1,15 @@
+"""Framework-level metadata router factory."""
+
+from fastapi import APIRouter
+
+from app.api.endpoints import metadata
+
+
+def create_metadata_router() -> APIRouter:
+    """
+    Create router for core metadata endpoints.
+
+    Currently wraps the existing metadata router to preserve behavior while
+    standardizing framework-level router factory composition.
+    """
+    return metadata.router

--- a/backend-migration/app/framework/api/metadata_runtime.py
+++ b/backend-migration/app/framework/api/metadata_runtime.py
@@ -19,7 +19,8 @@ from app.framework.schemas import (
     create_default_schema_registry,
     resolve_schema_plugin,
 )
-from app.framework.pipeline import PipelineRuntimeConfig, resolve_pipeline_definition
+from app.framework.functions import create_default_function_registry
+from app.framework.pipeline import PipelineEngine, PipelineRuntimeConfig, resolve_pipeline_definition
 
 # Stateless components (created once, reused)
 _llm_extractor = LLMExtractor()
@@ -35,6 +36,24 @@ def get_active_pipeline_definition():
     This is a runtime configuration entry point only; execution remains legacy for now.
     """
     return resolve_pipeline_definition(_pipeline_runtime_config)
+
+
+def run_pipeline_scaffold(
+    initial_payload: Optional[Dict[str, Any]] = None,
+    initial_metadata: Optional[Dict[str, Any]] = None,
+):
+    """
+    Execute the active pipeline via framework engine scaffold.
+
+    This helper is intentionally not used by legacy extraction paths yet.
+    """
+    pipeline = get_active_pipeline_definition()
+    engine = PipelineEngine(function_registry=create_default_function_registry())
+    return engine.execute(
+        pipeline=pipeline,
+        initial_payload=initial_payload,
+        initial_metadata=initial_metadata,
+    )
 
 
 def _build_enriched_metadata_via_plugin(

--- a/backend-migration/app/framework/api/metadata_runtime.py
+++ b/backend-migration/app/framework/api/metadata_runtime.py
@@ -1,6 +1,7 @@
 """Framework-internal metadata runtime with legacy-compatible behavior."""
 
 from datetime import datetime
+import os
 from typing import Any, Callable, Dict, List, Optional
 
 from app.adapters.extraction_metadata_collector import InMemoryExtractionMetadataCollector
@@ -27,6 +28,12 @@ _llm_extractor = LLMExtractor()
 _jsonld_builder = JSONLDBuilder()
 _schema_registry = create_default_schema_registry()
 _pipeline_runtime_config = PipelineRuntimeConfig()
+
+
+def _use_pipeline_runtime() -> bool:
+    """Feature flag for pipeline execution path (default: disabled)."""
+    raw = os.getenv("COMET_RS_USE_PIPELINE_RUNTIME", "0").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
 
 
 def get_active_pipeline_definition():
@@ -189,19 +196,32 @@ def run_extraction(
 ) -> tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
     """Run metadata extraction once and optionally enrich UI metadata fields."""
     schema = canonical_schema_name(_schema_registry, schema)
+    if _use_pipeline_runtime():
+        jsonld_document, extraction_metadata = run_extraction_via_pipeline(
+            repo_url=repo_url,
+            schema=schema,
+            access_token=access_token,
+        )
+        if with_enrichment and extraction_metadata:
+            enriched = _build_enriched_metadata_via_plugin(
+                jsonld_document=jsonld_document,
+                extraction_metadata=extraction_metadata,
+                schema=schema,
+            )
+            return jsonld_document, enriched
+        return jsonld_document, None
+
     use_case, _collector = create_extraction_use_case(
         repo_url=repo_url,
         access_token=access_token,
         with_enrichment=with_enrichment,
     )
-
     result = use_case.execute(repo_url=repo_url, schema=schema, access_token=access_token)
     jsonld_document = _build_jsonld_via_plugin(
         metadata=result.metadata,
         schema=schema,
         fallback_jsonld=result.jsonld_document,
     )
-
     if with_enrichment and result.extraction_metadata:
         enriched = _build_enriched_metadata_via_plugin(
             jsonld_document=jsonld_document,
@@ -221,6 +241,22 @@ def run_extraction_with_progress(
 ) -> tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
     """Run metadata extraction with optional step-level progress callbacks."""
     schema = canonical_schema_name(_schema_registry, schema)
+    if _use_pipeline_runtime():
+        jsonld_document, extraction_metadata = run_extraction_via_pipeline(
+            repo_url=repo_url,
+            schema=schema,
+            access_token=access_token,
+            progress_callback=progress_callback,
+        )
+        if with_enrichment and extraction_metadata:
+            enriched = _build_enriched_metadata_via_plugin(
+                jsonld_document=jsonld_document,
+                extraction_metadata=extraction_metadata,
+                schema=schema,
+            )
+            return jsonld_document, enriched
+        return jsonld_document, None
+
     use_case, _collector = create_extraction_use_case(
         repo_url=repo_url,
         access_token=access_token,

--- a/backend-migration/app/framework/api/metadata_runtime.py
+++ b/backend-migration/app/framework/api/metadata_runtime.py
@@ -1,0 +1,163 @@
+"""Framework-internal metadata runtime with legacy-compatible behavior."""
+
+from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional
+
+from app.adapters.extraction_metadata_collector import InMemoryExtractionMetadataCollector
+from app.adapters.external_data_fetcher_adapter import ExternalDataFetcherAdapter
+from app.adapters.factory import PlatformExtractorFactory
+from app.adapters.file_parser_adapter import FileParserAdapter
+from app.adapters.jsonld_builder import JSONLDBuilder
+from app.api.builders.enriched_metadata import build_enriched_metadata
+from app.application.use_cases.extract_metadata import ExtractMetadataUseCase
+from app.domain.services.llm_extractor import LLMExtractor
+from app.domain.services.url_pattern_matcher import URLPatternMatcher
+
+# Stateless components (created once, reused)
+_llm_extractor = LLMExtractor()
+_jsonld_builder = JSONLDBuilder()
+
+
+def create_extraction_use_case(
+    repo_url: str,
+    access_token: Optional[str],
+    with_enrichment: bool,
+) -> tuple[ExtractMetadataUseCase, Optional[InMemoryExtractionMetadataCollector]]:
+    """Create a fully wired extraction use case and optional enrichment collector."""
+    url_matcher = URLPatternMatcher()
+    platform = url_matcher.detect_platform(repo_url)
+    if not platform:
+        raise ValueError("Unsupported repository platform. Supported: GitHub, GitLab")
+
+    platform_extractor = PlatformExtractorFactory.create_extractor(repo_url, access_token)
+    file_parser = FileParserAdapter(platform, access_token)
+    external_data_fetcher = ExternalDataFetcherAdapter(platform, access_token)
+    collector = InMemoryExtractionMetadataCollector() if with_enrichment else None
+
+    use_case = ExtractMetadataUseCase(
+        platform_extractor=platform_extractor,
+        file_parser=file_parser,
+        external_data_fetcher=external_data_fetcher,
+        llm_extractor=_llm_extractor,
+        jsonld_builder=_jsonld_builder,
+        extraction_metadata_collector=collector,
+    )
+
+    return use_case, collector
+
+
+def run_extraction(
+    repo_url: str,
+    schema: str,
+    access_token: Optional[str],
+    with_enrichment: bool,
+) -> tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
+    """Run metadata extraction once and optionally enrich UI metadata fields."""
+    use_case, _collector = create_extraction_use_case(
+        repo_url=repo_url,
+        access_token=access_token,
+        with_enrichment=with_enrichment,
+    )
+
+    result = use_case.execute(repo_url=repo_url, schema=schema, access_token=access_token)
+    jsonld_document = result.jsonld_document
+
+    if with_enrichment and result.extraction_metadata:
+        enriched = build_enriched_metadata(
+            jsonld_document,
+            result.extraction_metadata,
+            schema,
+        )
+        return jsonld_document, enriched
+    return jsonld_document, None
+
+
+def run_extraction_with_progress(
+    repo_url: str,
+    schema: str,
+    access_token: Optional[str],
+    with_enrichment: bool,
+    progress_callback: Optional[Callable[[str, str], None]] = None,
+) -> tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
+    """Run metadata extraction with optional step-level progress callbacks."""
+    use_case, _collector = create_extraction_use_case(
+        repo_url=repo_url,
+        access_token=access_token,
+        with_enrichment=with_enrichment,
+    )
+
+    result = use_case.execute(
+        repo_url=repo_url,
+        schema=schema,
+        access_token=access_token,
+        progress_callback=progress_callback,
+    )
+    jsonld_document = result.jsonld_document
+
+    if with_enrichment and result.extraction_metadata:
+        enriched = build_enriched_metadata(
+            jsonld_document,
+            result.extraction_metadata,
+            schema,
+        )
+        return jsonld_document, enriched
+    return jsonld_document, None
+
+
+def run_single_property_extraction(
+    repo_url: str,
+    schema: str,
+    access_token: Optional[str],
+    property_name: str,
+) -> tuple[str, List[Dict[str, Any]]]:
+    """
+    Run extraction with enrichment and project to a single property's metadata.
+
+    Returns:
+        (extracted_at_iso, [ {profile, value, source, confidence}, ... ])
+    """
+    jsonld_document, enriched = run_extraction(
+        repo_url=repo_url,
+        schema=schema,
+        access_token=access_token,
+        with_enrichment=True,
+    )
+
+    extracted_at = datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+    results: List[Dict[str, Any]] = []
+    enriched = enriched or {}
+
+    if schema == "CODEMETA":
+        value = jsonld_document.get(property_name)
+        profile_key = "codemeta"
+        profile_meta = enriched.get(profile_key, {})
+        record = profile_meta.get(property_name, {})
+        results.append(
+            {
+                "profile": profile_key,
+                "value": value,
+                "source": record.get("source"),
+                "confidence": record.get("confidence"),
+            }
+        )
+        return extracted_at, results
+
+    for profile_key in ("maSMP:SoftwareSourceCode", "maSMP:SoftwareApplication"):
+        profile_data = jsonld_document.get(profile_key)
+        if not isinstance(profile_data, dict):
+            continue
+        if property_name not in profile_data:
+            continue
+        value = profile_data.get(property_name)
+        profile_meta = enriched.get(profile_key, {})
+        record = profile_meta.get(property_name, {})
+        results.append(
+            {
+                "profile": profile_key,
+                "value": value,
+                "source": record.get("source"),
+                "confidence": record.get("confidence"),
+            }
+        )
+
+    return extracted_at, results

--- a/backend-migration/app/framework/api/metadata_runtime.py
+++ b/backend-migration/app/framework/api/metadata_runtime.py
@@ -19,11 +19,22 @@ from app.framework.schemas import (
     create_default_schema_registry,
     resolve_schema_plugin,
 )
+from app.framework.pipeline import PipelineRuntimeConfig, resolve_pipeline_definition
 
 # Stateless components (created once, reused)
 _llm_extractor = LLMExtractor()
 _jsonld_builder = JSONLDBuilder()
 _schema_registry = create_default_schema_registry()
+_pipeline_runtime_config = PipelineRuntimeConfig()
+
+
+def get_active_pipeline_definition():
+    """
+    Resolve the active validated pipeline definition.
+
+    This is a runtime configuration entry point only; execution remains legacy for now.
+    """
+    return resolve_pipeline_definition(_pipeline_runtime_config)
 
 
 def _build_enriched_metadata_via_plugin(

--- a/backend-migration/app/framework/api/metadata_runtime.py
+++ b/backend-migration/app/framework/api/metadata_runtime.py
@@ -15,7 +15,9 @@ from app.domain.services.url_pattern_matcher import URLPatternMatcher
 from app.framework.schemas import (
     SchemaBuildContext,
     SchemaEnrichmentContext,
+    canonical_schema_name,
     create_default_schema_registry,
+    resolve_schema_plugin,
 )
 
 # Stateless components (created once, reused)
@@ -34,19 +36,20 @@ def _build_enriched_metadata_via_plugin(
 
     This keeps behavior stable while migrating enrichment logic to plugins.
     """
-    plugin = _schema_registry.get(schema)
-    if plugin:
-        try:
-            return plugin.enrich_output(
-                SchemaEnrichmentContext(
-                    jsonld_document=jsonld_document,
-                    extraction_metadata=extraction_metadata,
-                    raw_schema=schema,
-                )
+    try:
+        plugin = resolve_schema_plugin(_schema_registry, schema)
+        return plugin.enrich_output(
+            SchemaEnrichmentContext(
+                jsonld_document=jsonld_document,
+                extraction_metadata=extraction_metadata,
+                raw_schema=schema,
             )
-        except Exception:
-            # Keep existing behavior if plugin-based enrichment fails at runtime.
-            pass
+        )
+    except ValueError:
+        pass
+    except Exception:
+        # Keep existing behavior if plugin-based enrichment fails at runtime.
+        pass
     return build_enriched_metadata(jsonld_document, extraction_metadata, schema)
 
 
@@ -60,20 +63,21 @@ def _build_jsonld_via_plugin(
 
     This allows plugin-backed schema output without changing current behavior.
     """
-    plugin = _schema_registry.get(schema)
-    if plugin:
-        try:
-            has_release = bool(getattr(metadata, "has_release", False))
-            return plugin.build_output(
-                SchemaBuildContext(
-                    metadata=metadata,
-                    has_release=has_release,
-                    raw_schema=schema,
-                )
+    try:
+        plugin = resolve_schema_plugin(_schema_registry, schema)
+        has_release = bool(getattr(metadata, "has_release", False))
+        return plugin.build_output(
+            SchemaBuildContext(
+                metadata=metadata,
+                has_release=has_release,
+                raw_schema=schema,
             )
-        except Exception:
-            # Keep existing output if plugin path fails.
-            pass
+        )
+    except ValueError:
+        pass
+    except Exception:
+        # Keep existing output if plugin path fails.
+        pass
     return fallback_jsonld
 
 
@@ -112,6 +116,7 @@ def run_extraction(
     with_enrichment: bool,
 ) -> tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
     """Run metadata extraction once and optionally enrich UI metadata fields."""
+    schema = canonical_schema_name(_schema_registry, schema)
     use_case, _collector = create_extraction_use_case(
         repo_url=repo_url,
         access_token=access_token,
@@ -143,6 +148,7 @@ def run_extraction_with_progress(
     progress_callback: Optional[Callable[[str, str], None]] = None,
 ) -> tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
     """Run metadata extraction with optional step-level progress callbacks."""
+    schema = canonical_schema_name(_schema_registry, schema)
     use_case, _collector = create_extraction_use_case(
         repo_url=repo_url,
         access_token=access_token,

--- a/backend-migration/app/framework/api/metadata_runtime.py
+++ b/backend-migration/app/framework/api/metadata_runtime.py
@@ -12,10 +12,38 @@ from app.api.builders.enriched_metadata import build_enriched_metadata
 from app.application.use_cases.extract_metadata import ExtractMetadataUseCase
 from app.domain.services.llm_extractor import LLMExtractor
 from app.domain.services.url_pattern_matcher import URLPatternMatcher
+from app.framework.schemas import SchemaEnrichmentContext, create_default_schema_registry
 
 # Stateless components (created once, reused)
 _llm_extractor = LLMExtractor()
 _jsonld_builder = JSONLDBuilder()
+_schema_registry = create_default_schema_registry()
+
+
+def _build_enriched_metadata_via_plugin(
+    jsonld_document: Dict[str, Any],
+    extraction_metadata: Dict[str, Dict[str, Any]],
+    schema: str,
+) -> Dict[str, Any]:
+    """
+    Build enrichment through schema plugins with a safe legacy fallback.
+
+    This keeps behavior stable while migrating enrichment logic to plugins.
+    """
+    plugin = _schema_registry.get(schema)
+    if plugin:
+        try:
+            return plugin.enrich_output(
+                SchemaEnrichmentContext(
+                    jsonld_document=jsonld_document,
+                    extraction_metadata=extraction_metadata,
+                    raw_schema=schema,
+                )
+            )
+        except Exception:
+            # Keep existing behavior if plugin-based enrichment fails at runtime.
+            pass
+    return build_enriched_metadata(jsonld_document, extraction_metadata, schema)
 
 
 def create_extraction_use_case(
@@ -63,10 +91,10 @@ def run_extraction(
     jsonld_document = result.jsonld_document
 
     if with_enrichment and result.extraction_metadata:
-        enriched = build_enriched_metadata(
-            jsonld_document,
-            result.extraction_metadata,
-            schema,
+        enriched = _build_enriched_metadata_via_plugin(
+            jsonld_document=jsonld_document,
+            extraction_metadata=result.extraction_metadata,
+            schema=schema,
         )
         return jsonld_document, enriched
     return jsonld_document, None
@@ -95,10 +123,10 @@ def run_extraction_with_progress(
     jsonld_document = result.jsonld_document
 
     if with_enrichment and result.extraction_metadata:
-        enriched = build_enriched_metadata(
-            jsonld_document,
-            result.extraction_metadata,
-            schema,
+        enriched = _build_enriched_metadata_via_plugin(
+            jsonld_document=jsonld_document,
+            extraction_metadata=result.extraction_metadata,
+            schema=schema,
         )
         return jsonld_document, enriched
     return jsonld_document, None

--- a/backend-migration/app/framework/api/metadata_runtime.py
+++ b/backend-migration/app/framework/api/metadata_runtime.py
@@ -31,8 +31,8 @@ _pipeline_runtime_config = PipelineRuntimeConfig()
 
 
 def _use_pipeline_runtime() -> bool:
-    """Feature flag for pipeline execution path (default: disabled)."""
-    raw = os.getenv("COMET_RS_USE_PIPELINE_RUNTIME", "0").strip().lower()
+    """Feature flag for pipeline execution path (default: enabled)."""
+    raw = os.getenv("COMET_RS_USE_PIPELINE_RUNTIME", "1").strip().lower()
     return raw in {"1", "true", "yes", "on"}
 
 

--- a/backend-migration/app/framework/api/metadata_runtime.py
+++ b/backend-migration/app/framework/api/metadata_runtime.py
@@ -12,7 +12,11 @@ from app.api.builders.enriched_metadata import build_enriched_metadata
 from app.application.use_cases.extract_metadata import ExtractMetadataUseCase
 from app.domain.services.llm_extractor import LLMExtractor
 from app.domain.services.url_pattern_matcher import URLPatternMatcher
-from app.framework.schemas import SchemaEnrichmentContext, create_default_schema_registry
+from app.framework.schemas import (
+    SchemaBuildContext,
+    SchemaEnrichmentContext,
+    create_default_schema_registry,
+)
 
 # Stateless components (created once, reused)
 _llm_extractor = LLMExtractor()
@@ -44,6 +48,33 @@ def _build_enriched_metadata_via_plugin(
             # Keep existing behavior if plugin-based enrichment fails at runtime.
             pass
     return build_enriched_metadata(jsonld_document, extraction_metadata, schema)
+
+
+def _build_jsonld_via_plugin(
+    metadata: Any,
+    schema: str,
+    fallback_jsonld: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Build JSON-LD via schema plugin with fallback to existing use-case output.
+
+    This allows plugin-backed schema output without changing current behavior.
+    """
+    plugin = _schema_registry.get(schema)
+    if plugin:
+        try:
+            has_release = bool(getattr(metadata, "has_release", False))
+            return plugin.build_output(
+                SchemaBuildContext(
+                    metadata=metadata,
+                    has_release=has_release,
+                    raw_schema=schema,
+                )
+            )
+        except Exception:
+            # Keep existing output if plugin path fails.
+            pass
+    return fallback_jsonld
 
 
 def create_extraction_use_case(
@@ -88,7 +119,11 @@ def run_extraction(
     )
 
     result = use_case.execute(repo_url=repo_url, schema=schema, access_token=access_token)
-    jsonld_document = result.jsonld_document
+    jsonld_document = _build_jsonld_via_plugin(
+        metadata=result.metadata,
+        schema=schema,
+        fallback_jsonld=result.jsonld_document,
+    )
 
     if with_enrichment and result.extraction_metadata:
         enriched = _build_enriched_metadata_via_plugin(
@@ -120,7 +155,11 @@ def run_extraction_with_progress(
         access_token=access_token,
         progress_callback=progress_callback,
     )
-    jsonld_document = result.jsonld_document
+    jsonld_document = _build_jsonld_via_plugin(
+        metadata=result.metadata,
+        schema=schema,
+        fallback_jsonld=result.jsonld_document,
+    )
 
     if with_enrichment and result.extraction_metadata:
         enriched = _build_enriched_metadata_via_plugin(

--- a/backend-migration/app/framework/api/metadata_runtime.py
+++ b/backend-migration/app/framework/api/metadata_runtime.py
@@ -342,3 +342,73 @@ def run_single_property_extraction(
         )
 
     return extracted_at, results
+
+
+def compare_legacy_and_pipeline_extraction(
+    repo_url: str,
+    schema: str,
+    access_token: Optional[str],
+    with_enrichment: bool,
+) -> Dict[str, Any]:
+    """
+    Compare legacy and pipeline extraction outputs for parity checks.
+
+    Returns a compact diagnostics object with key-shape comparisons and
+    coarse equality flags. Full payloads are included for manual diffing.
+    """
+    schema = canonical_schema_name(_schema_registry, schema)
+
+    # Legacy path
+    use_case, _collector = create_extraction_use_case(
+        repo_url=repo_url,
+        access_token=access_token,
+        with_enrichment=with_enrichment,
+    )
+    legacy_result = use_case.execute(repo_url=repo_url, schema=schema, access_token=access_token)
+    legacy_jsonld = _build_jsonld_via_plugin(
+        metadata=legacy_result.metadata,
+        schema=schema,
+        fallback_jsonld=legacy_result.jsonld_document,
+    )
+    legacy_enriched: Optional[Dict[str, Any]] = None
+    if with_enrichment and legacy_result.extraction_metadata:
+        legacy_enriched = _build_enriched_metadata_via_plugin(
+            jsonld_document=legacy_jsonld,
+            extraction_metadata=legacy_result.extraction_metadata,
+            schema=schema,
+        )
+
+    # Pipeline path
+    pipeline_jsonld, pipeline_extraction_metadata = run_extraction_via_pipeline(
+        repo_url=repo_url,
+        schema=schema,
+        access_token=access_token,
+    )
+    pipeline_enriched: Optional[Dict[str, Any]] = None
+    if with_enrichment and pipeline_extraction_metadata:
+        pipeline_enriched = _build_enriched_metadata_via_plugin(
+            jsonld_document=pipeline_jsonld,
+            extraction_metadata=pipeline_extraction_metadata,
+            schema=schema,
+        )
+
+    legacy_jsonld_keys = sorted(legacy_jsonld.keys())
+    pipeline_jsonld_keys = sorted(pipeline_jsonld.keys())
+    legacy_enriched_profiles = sorted((legacy_enriched or {}).keys())
+    pipeline_enriched_profiles = sorted((pipeline_enriched or {}).keys())
+
+    return {
+        "schema": schema,
+        "jsonld_keys_match": legacy_jsonld_keys == pipeline_jsonld_keys,
+        "enriched_profiles_match": legacy_enriched_profiles == pipeline_enriched_profiles,
+        "jsonld_exact_match": legacy_jsonld == pipeline_jsonld,
+        "enriched_exact_match": legacy_enriched == pipeline_enriched,
+        "legacy_jsonld_keys": legacy_jsonld_keys,
+        "pipeline_jsonld_keys": pipeline_jsonld_keys,
+        "legacy_enriched_profiles": legacy_enriched_profiles,
+        "pipeline_enriched_profiles": pipeline_enriched_profiles,
+        "legacy_jsonld": legacy_jsonld,
+        "pipeline_jsonld": pipeline_jsonld,
+        "legacy_enriched": legacy_enriched,
+        "pipeline_enriched": pipeline_enriched,
+    }

--- a/backend-migration/app/framework/api/metadata_runtime.py
+++ b/backend-migration/app/framework/api/metadata_runtime.py
@@ -56,6 +56,48 @@ def run_pipeline_scaffold(
     )
 
 
+def run_extraction_via_pipeline(
+    repo_url: str,
+    schema: str,
+    access_token: Optional[str],
+    progress_callback: Optional[Callable[[str, str], None]] = None,
+) -> tuple[Dict[str, Any], Dict[str, Dict[str, Any]]]:
+    """
+    Execute extraction through the framework pipeline and return compatibility data.
+
+    Returns:
+        (jsonld_document, extraction_metadata)
+    """
+    schema = canonical_schema_name(_schema_registry, schema)
+    collector = InMemoryExtractionMetadataCollector()
+
+    payload = run_pipeline_scaffold(
+        initial_payload={
+            "repo_url": repo_url,
+            "schema": schema,
+            "access_token": access_token,
+            "extraction_metadata_collector": collector,
+        },
+    ) if progress_callback is None else PipelineEngine(
+        function_registry=create_default_function_registry()
+    ).execute(
+        pipeline=get_active_pipeline_definition(),
+        initial_payload={
+            "repo_url": repo_url,
+            "schema": schema,
+            "access_token": access_token,
+            "extraction_metadata_collector": collector,
+        },
+        progress_callback=progress_callback,
+    )
+
+    jsonld_document = payload.get("jsonld_document")
+    if not isinstance(jsonld_document, dict):
+        raise ValueError("Pipeline execution did not produce a valid 'jsonld_document'")
+
+    return jsonld_document, collector.get_all()
+
+
 def _build_enriched_metadata_via_plugin(
     jsonld_document: Dict[str, Any],
     extraction_metadata: Dict[str, Dict[str, Any]],

--- a/backend-migration/app/framework/api/public.py
+++ b/backend-migration/app/framework/api/public.py
@@ -1,0 +1,57 @@
+"""Framework-facing compatibility API for extraction and FAIRness."""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from app.api.services.fairness_service import run_fairness_assessment
+from app.framework.api.metadata_runtime import (
+    run_extraction,
+    run_single_property_extraction,
+)
+from app.core.entities.fairness import FairnessReport
+
+
+def extract_metadata(
+    repo_url: str,
+    schema: str = "maSMP",
+    *,
+    token: Optional[str] = None,
+    with_enrichment: bool = False,
+) -> Tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
+    """Compatibility wrapper for metadata extraction."""
+    return run_extraction(
+        repo_url=repo_url,
+        schema=schema,
+        access_token=token,
+        with_enrichment=with_enrichment,
+    )
+
+
+def extract_property(
+    repo_url: str,
+    property_name: str,
+    schema: str = "maSMP",
+    *,
+    token: Optional[str] = None,
+) -> Tuple[str, List[Dict[str, Any]]]:
+    """Compatibility wrapper for single-property extraction."""
+    return run_single_property_extraction(
+        repo_url=repo_url,
+        schema=schema,
+        access_token=token,
+        property_name=property_name,
+    )
+
+
+def assess_fairness(
+    repo_url: str,
+    schema: str = "maSMP",
+    *,
+    token: Optional[str] = None,
+) -> Tuple[Dict[str, Any], FairnessReport]:
+    """Compatibility wrapper for FAIRness assessment."""
+    return run_fairness_assessment(
+        repo_url=repo_url,
+        schema=schema,
+        access_token=token,
+        with_enrichment=False,
+    )

--- a/backend-migration/app/framework/api/system_router.py
+++ b/backend-migration/app/framework/api/system_router.py
@@ -1,0 +1,25 @@
+"""Framework-level system router factory."""
+
+from fastapi import APIRouter
+
+
+def create_system_router() -> APIRouter:
+    """Create router for lightweight system/info endpoints."""
+    router = APIRouter(prefix="/api", tags=["Metadata"])
+
+    @router.get("/health")
+    async def health_check():
+        """Health check endpoint."""
+        return {"status": "healthy", "service": "metadata-extractor"}
+
+    @router.get("/platforms")
+    async def get_supported_platforms():
+        """Get list of supported platforms."""
+        return {
+            "platforms": [
+                {"name": "GitHub", "url_pattern": "github.com", "description": "GitHub repositories"},
+                {"name": "GitLab", "url_pattern": "gitlab.com", "description": "GitLab repositories"},
+            ]
+        }
+
+    return router

--- a/backend-migration/app/framework/functions/__init__.py
+++ b/backend-migration/app/framework/functions/__init__.py
@@ -1,0 +1,1 @@
+"""Function plugin layer."""

--- a/backend-migration/app/framework/functions/__init__.py
+++ b/backend-migration/app/framework/functions/__init__.py
@@ -1,1 +1,17 @@
 """Function plugin layer."""
+
+from app.framework.functions.plugin import (
+    FunctionContext,
+    FunctionPlugin,
+    FunctionResult,
+    RetryPolicy,
+)
+from app.framework.functions.registry import FunctionRegistry
+
+__all__ = [
+    "RetryPolicy",
+    "FunctionContext",
+    "FunctionResult",
+    "FunctionPlugin",
+    "FunctionRegistry",
+]

--- a/backend-migration/app/framework/functions/__init__.py
+++ b/backend-migration/app/framework/functions/__init__.py
@@ -6,6 +6,14 @@ from app.framework.functions.plugin import (
     FunctionResult,
     RetryPolicy,
 )
+from app.framework.functions.default_plugins import (
+    ExternalEnrichmentPlugin,
+    FileParsingPlugin,
+    LLMEnrichmentPlugin,
+    PlatformExtractionPlugin,
+    SchemaBuildPlugin,
+)
+from app.framework.functions.default_registry import create_default_function_registry
 from app.framework.functions.registry import FunctionRegistry
 
 __all__ = [
@@ -14,4 +22,10 @@ __all__ = [
     "FunctionResult",
     "FunctionPlugin",
     "FunctionRegistry",
+    "PlatformExtractionPlugin",
+    "FileParsingPlugin",
+    "ExternalEnrichmentPlugin",
+    "LLMEnrichmentPlugin",
+    "SchemaBuildPlugin",
+    "create_default_function_registry",
 ]

--- a/backend-migration/app/framework/functions/default_plugins.py
+++ b/backend-migration/app/framework/functions/default_plugins.py
@@ -1,0 +1,90 @@
+"""Default first-party function plugin stubs for extraction stages."""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Tuple
+
+from app.framework.functions.plugin import (
+    FunctionContext,
+    FunctionPlugin,
+    FunctionResult,
+    RetryPolicy,
+)
+
+
+@dataclass(frozen=True)
+class _BaseStagePlugin:
+    """Shared defaults for stage plugin stubs."""
+
+    id: str
+    inputs: Tuple[str, ...] = field(default_factory=tuple)
+    outputs: Tuple[str, ...] = field(default_factory=tuple)
+    retry_policy: Optional[RetryPolicy] = None
+    plugin_metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def run(self, context: FunctionContext) -> FunctionResult:
+        """
+        Pass-through stub.
+
+        Runtime integration will replace this with concrete stage execution.
+        """
+        return FunctionResult(payload=context.payload, metadata=context.metadata)
+
+
+class PlatformExtractionPlugin(_BaseStagePlugin, FunctionPlugin):
+    """Stage 1: platform metadata extraction."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            id="platform_extraction",
+            inputs=("repo_url", "access_token"),
+            outputs=("metadata",),
+            plugin_metadata={"stage": 1, "name": "platform"},
+        )
+
+
+class FileParsingPlugin(_BaseStagePlugin, FunctionPlugin):
+    """Stage 2: repository file parsing."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            id="file_parsing",
+            inputs=("repo_url", "metadata", "access_token"),
+            outputs=("metadata", "doi", "reference_extracted"),
+            plugin_metadata={"stage": 2, "name": "file_parsing"},
+        )
+
+
+class ExternalEnrichmentPlugin(_BaseStagePlugin, FunctionPlugin):
+    """Stage 3: external data enrichment."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            id="external_enrichment",
+            inputs=("repo_url", "metadata", "doi", "reference_extracted", "access_token"),
+            outputs=("metadata",),
+            plugin_metadata={"stage": 3, "name": "external_data"},
+        )
+
+
+class LLMEnrichmentPlugin(_BaseStagePlugin, FunctionPlugin):
+    """Stage 4: LLM-based enrichment."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            id="llm_enrichment",
+            inputs=("repo_url", "metadata"),
+            outputs=("metadata",),
+            plugin_metadata={"stage": 4, "name": "llm"},
+        )
+
+
+class SchemaBuildPlugin(_BaseStagePlugin, FunctionPlugin):
+    """Stage 5: schema output build."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            id="schema_build",
+            inputs=("metadata", "schema"),
+            outputs=("jsonld_document",),
+            plugin_metadata={"stage": 5, "name": "jsonld_build"},
+        )

--- a/backend-migration/app/framework/functions/default_plugins.py
+++ b/backend-migration/app/framework/functions/default_plugins.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Optional, Tuple
 
 from app.adapters.factory import PlatformExtractorFactory
 from app.adapters.file_parser_adapter import FileParserAdapter
+from app.adapters.external_data_fetcher_adapter import ExternalDataFetcherAdapter
 from app.framework.functions.plugin import (
     FunctionContext,
     FunctionPlugin,
@@ -146,6 +147,55 @@ class ExternalEnrichmentPlugin(_BaseStagePlugin, FunctionPlugin):
             outputs=("metadata",),
             plugin_metadata={"stage": 3, "name": "external_data"},
         )
+
+    def run(self, context: FunctionContext) -> FunctionResult:
+        """
+        Execute real external enrichment using the external data fetcher adapter.
+
+        Required payload keys:
+        - repo_url
+        - metadata
+        Optional payload keys:
+        - doi
+        - reference_extracted
+        - access_token
+        - platform (if omitted, detected from repo_url)
+        - extraction_metadata_collector
+        """
+        repo_url = context.payload.get("repo_url")
+        if not repo_url:
+            raise ValueError("external_enrichment requires 'repo_url' in payload")
+
+        metadata = context.payload.get("metadata")
+        if metadata is None:
+            raise ValueError("external_enrichment requires 'metadata' in payload")
+
+        access_token = context.payload.get("access_token")
+        doi = context.payload.get("doi")
+        reference_extracted = bool(context.payload.get("reference_extracted", False))
+        collector = context.payload.get("extraction_metadata_collector")
+        platform = context.payload.get("platform")
+
+        if not platform:
+            matcher = URLPatternMatcher()
+            platform = matcher.detect_platform(str(repo_url))
+        if not platform:
+            raise ValueError("Unsupported repository platform. Supported: GitHub, GitLab")
+
+        fetcher = ExternalDataFetcherAdapter(platform=str(platform), access_token=access_token)
+        updated_metadata = fetcher.fetch_external_data(
+            str(repo_url),
+            metadata,
+            doi=doi,
+            reference_extracted=reference_extracted,
+            access_token=access_token,
+            extraction_metadata=collector,
+        )
+
+        payload = dict(context.payload)
+        payload["metadata"] = updated_metadata
+        payload["platform"] = platform
+        return FunctionResult(payload=payload, metadata=context.metadata)
 
 
 class LLMEnrichmentPlugin(_BaseStagePlugin, FunctionPlugin):

--- a/backend-migration/app/framework/functions/default_plugins.py
+++ b/backend-migration/app/framework/functions/default_plugins.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Tuple
 
 from app.adapters.factory import PlatformExtractorFactory
+from app.adapters.file_parser_adapter import FileParserAdapter
 from app.framework.functions.plugin import (
     FunctionContext,
     FunctionPlugin,
@@ -88,6 +89,51 @@ class FileParsingPlugin(_BaseStagePlugin, FunctionPlugin):
             outputs=("metadata", "doi", "reference_extracted"),
             plugin_metadata={"stage": 2, "name": "file_parsing"},
         )
+
+    def run(self, context: FunctionContext) -> FunctionResult:
+        """
+        Execute real file parsing using existing file parser adapter.
+
+        Required payload keys:
+        - repo_url
+        - metadata (from platform extraction stage)
+        Optional payload keys:
+        - access_token
+        - platform (if omitted, detected from repo_url)
+        - extraction_metadata_collector
+        """
+        repo_url = context.payload.get("repo_url")
+        if not repo_url:
+            raise ValueError("file_parsing requires 'repo_url' in payload")
+
+        metadata = context.payload.get("metadata")
+        if metadata is None:
+            raise ValueError("file_parsing requires 'metadata' in payload")
+
+        access_token = context.payload.get("access_token")
+        collector = context.payload.get("extraction_metadata_collector")
+        platform = context.payload.get("platform")
+
+        if not platform:
+            matcher = URLPatternMatcher()
+            platform = matcher.detect_platform(str(repo_url))
+        if not platform:
+            raise ValueError("Unsupported repository platform. Supported: GitHub, GitLab")
+
+        parser = FileParserAdapter(platform=str(platform), access_token=access_token)
+        updated_metadata, doi, reference_extracted = parser.parse_files(
+            str(repo_url),
+            metadata,
+            access_token=access_token,
+            extraction_metadata=collector,
+        )
+
+        payload = dict(context.payload)
+        payload["metadata"] = updated_metadata
+        payload["doi"] = doi
+        payload["reference_extracted"] = reference_extracted
+        payload["platform"] = platform
+        return FunctionResult(payload=payload, metadata=context.metadata)
 
 
 class ExternalEnrichmentPlugin(_BaseStagePlugin, FunctionPlugin):

--- a/backend-migration/app/framework/functions/default_plugins.py
+++ b/backend-migration/app/framework/functions/default_plugins.py
@@ -3,12 +3,14 @@
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Tuple
 
+from app.adapters.factory import PlatformExtractorFactory
 from app.framework.functions.plugin import (
     FunctionContext,
     FunctionPlugin,
     FunctionResult,
     RetryPolicy,
 )
+from app.domain.services.url_pattern_matcher import URLPatternMatcher
 
 
 @dataclass(frozen=True)
@@ -40,6 +42,40 @@ class PlatformExtractionPlugin(_BaseStagePlugin, FunctionPlugin):
             outputs=("metadata",),
             plugin_metadata={"stage": 1, "name": "platform"},
         )
+
+    def run(self, context: FunctionContext) -> FunctionResult:
+        """
+        Execute real platform extraction using existing adapters.
+
+        Required payload keys:
+        - repo_url: repository URL
+        Optional payload keys:
+        - access_token: auth token for private repos
+        - extraction_metadata_collector: collector compatible with adapter contracts
+        """
+        repo_url = context.payload.get("repo_url")
+        if not repo_url:
+            raise ValueError("platform_extraction requires 'repo_url' in payload")
+
+        access_token = context.payload.get("access_token")
+        collector = context.payload.get("extraction_metadata_collector")
+
+        matcher = URLPatternMatcher()
+        platform = matcher.detect_platform(str(repo_url))
+        if not platform:
+            raise ValueError("Unsupported repository platform. Supported: GitHub, GitLab")
+
+        extractor = PlatformExtractorFactory.create_extractor(str(repo_url), access_token)
+        metadata = extractor.extract_platform_metadata(
+            str(repo_url),
+            access_token=access_token,
+            extraction_metadata=collector,
+        )
+
+        payload = dict(context.payload)
+        payload["metadata"] = metadata
+        payload["platform"] = platform
+        return FunctionResult(payload=payload, metadata=context.metadata)
 
 
 class FileParsingPlugin(_BaseStagePlugin, FunctionPlugin):

--- a/backend-migration/app/framework/functions/default_plugins.py
+++ b/backend-migration/app/framework/functions/default_plugins.py
@@ -14,8 +14,15 @@ from app.framework.functions.plugin import (
     RetryPolicy,
 )
 from app.domain.services.url_pattern_matcher import URLPatternMatcher
+from app.framework.schemas import (
+    SchemaBuildContext,
+    canonical_schema_name,
+    create_default_schema_registry,
+    resolve_schema_plugin,
+)
 
 _llm_extractor = LLMExtractor()
+_schema_registry = create_default_schema_registry()
 
 
 @dataclass(frozen=True)
@@ -256,3 +263,35 @@ class SchemaBuildPlugin(_BaseStagePlugin, FunctionPlugin):
             outputs=("jsonld_document",),
             plugin_metadata={"stage": 5, "name": "jsonld_build"},
         )
+
+    def run(self, context: FunctionContext) -> FunctionResult:
+        """
+        Build JSON-LD output using schema plugin registry.
+
+        Required payload keys:
+        - metadata
+        - schema
+        """
+        metadata = context.payload.get("metadata")
+        if metadata is None:
+            raise ValueError("schema_build requires 'metadata' in payload")
+
+        raw_schema = context.payload.get("schema")
+        if not raw_schema:
+            raise ValueError("schema_build requires 'schema' in payload")
+
+        schema = canonical_schema_name(_schema_registry, str(raw_schema))
+        plugin = resolve_schema_plugin(_schema_registry, schema)
+        has_release = bool(getattr(metadata, "has_release", False))
+        jsonld_document = plugin.build_output(
+            SchemaBuildContext(
+                metadata=metadata,
+                has_release=has_release,
+                raw_schema=str(raw_schema),
+            )
+        )
+
+        payload = dict(context.payload)
+        payload["schema"] = schema
+        payload["jsonld_document"] = jsonld_document
+        return FunctionResult(payload=payload, metadata=context.metadata)

--- a/backend-migration/app/framework/functions/default_plugins.py
+++ b/backend-migration/app/framework/functions/default_plugins.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Optional, Tuple
 from app.adapters.factory import PlatformExtractorFactory
 from app.adapters.file_parser_adapter import FileParserAdapter
 from app.adapters.external_data_fetcher_adapter import ExternalDataFetcherAdapter
+from app.domain.services.llm_extractor import LLMExtractor
 from app.framework.functions.plugin import (
     FunctionContext,
     FunctionPlugin,
@@ -13,6 +14,8 @@ from app.framework.functions.plugin import (
     RetryPolicy,
 )
 from app.domain.services.url_pattern_matcher import URLPatternMatcher
+
+_llm_extractor = LLMExtractor()
 
 
 @dataclass(frozen=True)
@@ -208,6 +211,39 @@ class LLMEnrichmentPlugin(_BaseStagePlugin, FunctionPlugin):
             outputs=("metadata",),
             plugin_metadata={"stage": 4, "name": "llm"},
         )
+
+    def run(self, context: FunctionContext) -> FunctionResult:
+        """
+        Execute LLM enrichment using existing domain LLM extractor.
+
+        Required payload keys:
+        - repo_url
+        - metadata
+        Optional payload keys:
+        - extraction_metadata_collector
+        """
+        repo_url = context.payload.get("repo_url")
+        if not repo_url:
+            raise ValueError("llm_enrichment requires 'repo_url' in payload")
+
+        metadata = context.payload.get("metadata")
+        if metadata is None:
+            raise ValueError("llm_enrichment requires 'metadata' in payload")
+
+        collector = context.payload.get("extraction_metadata_collector")
+        payload = dict(context.payload)
+
+        # Keep legacy behavior: LLM errors should not fail the entire extraction flow.
+        try:
+            payload["metadata"] = _llm_extractor.extract_with_llm(
+                metadata=metadata,
+                repo_url=str(repo_url),
+                extraction_metadata=collector,
+            )
+        except Exception:
+            payload["metadata"] = metadata
+
+        return FunctionResult(payload=payload, metadata=context.metadata)
 
 
 class SchemaBuildPlugin(_BaseStagePlugin, FunctionPlugin):

--- a/backend-migration/app/framework/functions/default_registry.py
+++ b/backend-migration/app/framework/functions/default_registry.py
@@ -1,0 +1,25 @@
+"""Factory for default first-party function plugin registry."""
+
+from app.framework.functions.default_plugins import (
+    ExternalEnrichmentPlugin,
+    FileParsingPlugin,
+    LLMEnrichmentPlugin,
+    PlatformExtractionPlugin,
+    SchemaBuildPlugin,
+)
+from app.framework.functions.registry import FunctionRegistry
+
+
+def create_default_function_registry() -> FunctionRegistry:
+    """Return registry preloaded with default 5-stage extraction plugins."""
+    registry = FunctionRegistry()
+    registry.register_many(
+        [
+            PlatformExtractionPlugin(),
+            FileParsingPlugin(),
+            ExternalEnrichmentPlugin(),
+            LLMEnrichmentPlugin(),
+            SchemaBuildPlugin(),
+        ]
+    )
+    return registry

--- a/backend-migration/app/framework/functions/plugin.py
+++ b/backend-migration/app/framework/functions/plugin.py
@@ -1,0 +1,37 @@
+"""Function plugin contract and execution context types."""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Protocol
+
+
+RetryPolicy = Dict[str, Any]
+
+
+@dataclass(frozen=True)
+class FunctionContext:
+    """Execution context passed to function plugins."""
+
+    payload: Dict[str, Any] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class FunctionResult:
+    """Standardized function plugin output."""
+
+    payload: Dict[str, Any] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+class FunctionPlugin(Protocol):
+    """Contract for pluggable pipeline functions."""
+
+    id: str
+    inputs: tuple[str, ...]
+    outputs: tuple[str, ...]
+    retry_policy: Optional[RetryPolicy]
+    plugin_metadata: Dict[str, Any]
+
+    def run(self, context: FunctionContext) -> FunctionResult:
+        """Execute plugin logic using context and return normalized output."""
+        ...

--- a/backend-migration/app/framework/functions/registry.py
+++ b/backend-migration/app/framework/functions/registry.py
@@ -1,0 +1,36 @@
+"""In-memory registry for function plugins."""
+
+from typing import Dict, Iterable, Optional
+
+from app.framework.functions.plugin import FunctionPlugin
+
+
+class FunctionRegistry:
+    """Stores and resolves function plugins by plugin ID."""
+
+    def __init__(self) -> None:
+        self._plugins: Dict[str, FunctionPlugin] = {}
+
+    def register(self, plugin: FunctionPlugin) -> None:
+        """Register or replace a plugin using normalized ID."""
+        self._plugins[plugin.id] = plugin
+
+    def register_many(self, plugins: Iterable[FunctionPlugin]) -> None:
+        """Register multiple plugins."""
+        for plugin in plugins:
+            self.register(plugin)
+
+    def get(self, plugin_id: str) -> Optional[FunctionPlugin]:
+        """Get a plugin by ID, or None if missing."""
+        return self._plugins.get(plugin_id)
+
+    def require(self, plugin_id: str) -> FunctionPlugin:
+        """Get a plugin by ID or raise a descriptive error."""
+        plugin = self.get(plugin_id)
+        if not plugin:
+            raise ValueError(f"No function plugin registered for '{plugin_id}'")
+        return plugin
+
+    def list_ids(self) -> list[str]:
+        """Return registered plugin IDs in stable sorted order."""
+        return sorted(self._plugins.keys())

--- a/backend-migration/app/framework/pipeline/__init__.py
+++ b/backend-migration/app/framework/pipeline/__init__.py
@@ -1,1 +1,11 @@
 """Pipeline composition and execution layer."""
+
+from app.framework.pipeline.engine import PipelineEngine, PipelineValidationError
+from app.framework.pipeline.types import PipelineDefinition, PipelineStep
+
+__all__ = [
+    "PipelineStep",
+    "PipelineDefinition",
+    "PipelineEngine",
+    "PipelineValidationError",
+]

--- a/backend-migration/app/framework/pipeline/__init__.py
+++ b/backend-migration/app/framework/pipeline/__init__.py
@@ -1,6 +1,10 @@
 """Pipeline composition and execution layer."""
 
-from app.framework.pipeline.engine import PipelineEngine, PipelineValidationError
+from app.framework.pipeline.engine import (
+    PipelineEngine,
+    PipelineExecutionError,
+    PipelineValidationError,
+)
 from app.framework.pipeline.default_pipeline import create_default_pipeline_definition
 from app.framework.pipeline.defaults import (
     create_validated_default_pipeline,
@@ -17,6 +21,7 @@ __all__ = [
     "PipelineStep",
     "PipelineDefinition",
     "PipelineEngine",
+    "PipelineExecutionError",
     "PipelineValidationError",
     "create_default_pipeline_definition",
     "create_validated_default_pipeline",

--- a/backend-migration/app/framework/pipeline/__init__.py
+++ b/backend-migration/app/framework/pipeline/__init__.py
@@ -8,6 +8,10 @@ from app.framework.pipeline.defaults import (
 )
 from app.framework.pipeline.types import PipelineDefinition, PipelineStep
 from app.framework.pipeline.yaml_loader import load_pipeline_definition_from_yaml
+from app.framework.pipeline.runtime_config import (
+    PipelineRuntimeConfig,
+    resolve_pipeline_definition,
+)
 
 __all__ = [
     "PipelineStep",
@@ -18,4 +22,6 @@ __all__ = [
     "create_validated_default_pipeline",
     "load_pipeline_definition_from_yaml",
     "load_and_validate_pipeline_from_yaml",
+    "PipelineRuntimeConfig",
+    "resolve_pipeline_definition",
 ]

--- a/backend-migration/app/framework/pipeline/__init__.py
+++ b/backend-migration/app/framework/pipeline/__init__.py
@@ -2,8 +2,12 @@
 
 from app.framework.pipeline.engine import PipelineEngine, PipelineValidationError
 from app.framework.pipeline.default_pipeline import create_default_pipeline_definition
-from app.framework.pipeline.defaults import create_validated_default_pipeline
+from app.framework.pipeline.defaults import (
+    create_validated_default_pipeline,
+    load_and_validate_pipeline_from_yaml,
+)
 from app.framework.pipeline.types import PipelineDefinition, PipelineStep
+from app.framework.pipeline.yaml_loader import load_pipeline_definition_from_yaml
 
 __all__ = [
     "PipelineStep",
@@ -12,4 +16,6 @@ __all__ = [
     "PipelineValidationError",
     "create_default_pipeline_definition",
     "create_validated_default_pipeline",
+    "load_pipeline_definition_from_yaml",
+    "load_and_validate_pipeline_from_yaml",
 ]

--- a/backend-migration/app/framework/pipeline/__init__.py
+++ b/backend-migration/app/framework/pipeline/__init__.py
@@ -1,0 +1,1 @@
+"""Pipeline composition and execution layer."""

--- a/backend-migration/app/framework/pipeline/__init__.py
+++ b/backend-migration/app/framework/pipeline/__init__.py
@@ -1,6 +1,8 @@
 """Pipeline composition and execution layer."""
 
 from app.framework.pipeline.engine import PipelineEngine, PipelineValidationError
+from app.framework.pipeline.default_pipeline import create_default_pipeline_definition
+from app.framework.pipeline.defaults import create_validated_default_pipeline
 from app.framework.pipeline.types import PipelineDefinition, PipelineStep
 
 __all__ = [
@@ -8,4 +10,6 @@ __all__ = [
     "PipelineDefinition",
     "PipelineEngine",
     "PipelineValidationError",
+    "create_default_pipeline_definition",
+    "create_validated_default_pipeline",
 ]

--- a/backend-migration/app/framework/pipeline/default_pipeline.py
+++ b/backend-migration/app/framework/pipeline/default_pipeline.py
@@ -39,5 +39,9 @@ def create_default_pipeline_definition() -> PipelineDefinition:
                 outputs=("jsonld_document",),
             ),
         ),
-        metadata={"version": 1, "compatibility": "legacy-5-step"},
+        metadata={
+            "version": 1,
+            "compatibility": "legacy-5-step",
+            "runtime_inputs": ["repo_url", "access_token", "schema", "extraction_metadata_collector"],
+        },
     )

--- a/backend-migration/app/framework/pipeline/default_pipeline.py
+++ b/backend-migration/app/framework/pipeline/default_pipeline.py
@@ -1,0 +1,43 @@
+"""Default backward-compatible 5-step pipeline definition."""
+
+from app.framework.pipeline.types import PipelineDefinition, PipelineStep
+
+
+def create_default_pipeline_definition() -> PipelineDefinition:
+    """Return the default extraction pipeline matching the current 5-step flow."""
+    return PipelineDefinition(
+        id="default_metadata_extraction",
+        steps=(
+            PipelineStep(
+                id="platform",
+                plugin_id="platform_extraction",
+                inputs=("repo_url", "access_token"),
+                outputs=("metadata",),
+            ),
+            PipelineStep(
+                id="file_parsing",
+                plugin_id="file_parsing",
+                inputs=("repo_url", "metadata", "access_token"),
+                outputs=("metadata", "doi", "reference_extracted"),
+            ),
+            PipelineStep(
+                id="external_data",
+                plugin_id="external_enrichment",
+                inputs=("repo_url", "metadata", "doi", "reference_extracted", "access_token"),
+                outputs=("metadata",),
+            ),
+            PipelineStep(
+                id="llm",
+                plugin_id="llm_enrichment",
+                inputs=("repo_url", "metadata"),
+                outputs=("metadata",),
+            ),
+            PipelineStep(
+                id="jsonld_build",
+                plugin_id="schema_build",
+                inputs=("metadata", "schema"),
+                outputs=("jsonld_document",),
+            ),
+        ),
+        metadata={"version": 1, "compatibility": "legacy-5-step"},
+    )

--- a/backend-migration/app/framework/pipeline/defaults.py
+++ b/backend-migration/app/framework/pipeline/defaults.py
@@ -1,9 +1,12 @@
 """Factories for default pipeline engine + definition bootstrap."""
 
+from pathlib import Path
+
 from app.framework.functions import create_default_function_registry
 from app.framework.pipeline.default_pipeline import create_default_pipeline_definition
 from app.framework.pipeline.engine import PipelineEngine
 from app.framework.pipeline.types import PipelineDefinition
+from app.framework.pipeline.yaml_loader import load_pipeline_definition_from_yaml
 
 
 def create_validated_default_pipeline() -> PipelineDefinition:
@@ -11,5 +14,14 @@ def create_validated_default_pipeline() -> PipelineDefinition:
     function_registry = create_default_function_registry()
     engine = PipelineEngine(function_registry=function_registry)
     pipeline = create_default_pipeline_definition()
+    engine.validate(pipeline)
+    return pipeline
+
+
+def load_and_validate_pipeline_from_yaml(path: str | Path) -> PipelineDefinition:
+    """Load a pipeline from YAML and validate against default function plugins."""
+    function_registry = create_default_function_registry()
+    engine = PipelineEngine(function_registry=function_registry)
+    pipeline = load_pipeline_definition_from_yaml(path)
     engine.validate(pipeline)
     return pipeline

--- a/backend-migration/app/framework/pipeline/defaults.py
+++ b/backend-migration/app/framework/pipeline/defaults.py
@@ -1,0 +1,15 @@
+"""Factories for default pipeline engine + definition bootstrap."""
+
+from app.framework.functions import create_default_function_registry
+from app.framework.pipeline.default_pipeline import create_default_pipeline_definition
+from app.framework.pipeline.engine import PipelineEngine
+from app.framework.pipeline.types import PipelineDefinition
+
+
+def create_validated_default_pipeline() -> PipelineDefinition:
+    """Build and validate the default pipeline against default function plugins."""
+    function_registry = create_default_function_registry()
+    engine = PipelineEngine(function_registry=function_registry)
+    pipeline = create_default_pipeline_definition()
+    engine.validate(pipeline)
+    return pipeline

--- a/backend-migration/app/framework/pipeline/engine.py
+++ b/backend-migration/app/framework/pipeline/engine.py
@@ -1,5 +1,8 @@
 """Pipeline engine (validation-first scaffold)."""
 
+from typing import Any, Callable, Dict, Optional
+
+from app.framework.functions.plugin import FunctionContext
 from app.framework.functions.registry import FunctionRegistry
 from app.framework.pipeline.types import PipelineDefinition, PipelineStep
 
@@ -8,12 +11,16 @@ class PipelineValidationError(ValueError):
     """Raised when a pipeline definition is invalid."""
 
 
+class PipelineExecutionError(RuntimeError):
+    """Raised when pipeline execution fails."""
+
+
 class PipelineEngine:
     """
     Validation-first pipeline engine.
 
-    This scaffold validates plugin references and basic step wiring.
-    Execution support will be added in a later atomic step.
+    This scaffold validates plugin references and supports basic sequential
+    execution over registered function plugins.
     """
 
     def __init__(self, function_registry: FunctionRegistry) -> None:
@@ -32,6 +39,38 @@ class PipelineEngine:
             self._validate_plugin_exists(step)
             self._validate_input_wiring(step, available_keys)
             available_keys.update(step.outputs)
+
+    def execute(
+        self,
+        pipeline: PipelineDefinition,
+        initial_payload: Optional[Dict[str, Any]] = None,
+        initial_metadata: Optional[Dict[str, Any]] = None,
+        progress_callback: Optional[Callable[[str, str], None]] = None,
+    ) -> Dict[str, Any]:
+        """Execute pipeline sequentially and return the final payload context."""
+        self.validate(pipeline)
+
+        payload: Dict[str, Any] = dict(initial_payload or {})
+        metadata: Dict[str, Any] = dict(initial_metadata or {})
+
+        for step in pipeline.steps:
+            plugin = self._function_registry.require(step.plugin_id)
+            if progress_callback:
+                progress_callback(step.id, "started")
+            try:
+                result = plugin.run(FunctionContext(payload=payload, metadata=metadata))
+            except Exception as exc:
+                raise PipelineExecutionError(
+                    f"Step '{step.id}' failed while running plugin '{step.plugin_id}'"
+                ) from exc
+
+            payload.update(result.payload)
+            metadata.update(result.metadata)
+
+            if progress_callback:
+                progress_callback(step.id, "completed")
+
+        return payload
 
     def _validate_step_id(self, step: PipelineStep, seen_ids: set[str]) -> None:
         if step.id in seen_ids:

--- a/backend-migration/app/framework/pipeline/engine.py
+++ b/backend-migration/app/framework/pipeline/engine.py
@@ -1,0 +1,57 @@
+"""Pipeline engine (validation-first scaffold)."""
+
+from app.framework.functions.registry import FunctionRegistry
+from app.framework.pipeline.types import PipelineDefinition, PipelineStep
+
+
+class PipelineValidationError(ValueError):
+    """Raised when a pipeline definition is invalid."""
+
+
+class PipelineEngine:
+    """
+    Validation-first pipeline engine.
+
+    This scaffold validates plugin references and basic step wiring.
+    Execution support will be added in a later atomic step.
+    """
+
+    def __init__(self, function_registry: FunctionRegistry) -> None:
+        self._function_registry = function_registry
+
+    def validate(self, pipeline: PipelineDefinition) -> None:
+        """Validate plugin existence, unique step IDs, and simple wiring."""
+        if not pipeline.steps:
+            raise PipelineValidationError("Pipeline must define at least one step")
+
+        seen_ids: set[str] = set()
+        available_keys: set[str] = set()
+
+        for step in pipeline.steps:
+            self._validate_step_id(step, seen_ids)
+            self._validate_plugin_exists(step)
+            self._validate_input_wiring(step, available_keys)
+            available_keys.update(step.outputs)
+
+    def _validate_step_id(self, step: PipelineStep, seen_ids: set[str]) -> None:
+        if step.id in seen_ids:
+            raise PipelineValidationError(f"Duplicate pipeline step id '{step.id}'")
+        seen_ids.add(step.id)
+
+    def _validate_plugin_exists(self, step: PipelineStep) -> None:
+        if self._function_registry.get(step.plugin_id) is None:
+            raise PipelineValidationError(
+                f"Step '{step.id}' references unknown plugin '{step.plugin_id}'"
+            )
+
+    def _validate_input_wiring(self, step: PipelineStep, available_keys: set[str]) -> None:
+        # Inputs may be supplied by pipeline start context or previous steps.
+        missing = [key for key in step.inputs if key not in available_keys]
+        if not missing:
+            return
+        if len(available_keys) == 0:
+            return
+        missing_csv = ", ".join(sorted(set(missing)))
+        raise PipelineValidationError(
+            f"Step '{step.id}' has unresolved inputs: {missing_csv}"
+        )

--- a/backend-migration/app/framework/pipeline/engine.py
+++ b/backend-migration/app/framework/pipeline/engine.py
@@ -32,7 +32,12 @@ class PipelineEngine:
             raise PipelineValidationError("Pipeline must define at least one step")
 
         seen_ids: set[str] = set()
-        available_keys: set[str] = set()
+        runtime_inputs = pipeline.metadata.get("runtime_inputs", [])
+        if runtime_inputs is None:
+            runtime_inputs = []
+        if not isinstance(runtime_inputs, list):
+            raise PipelineValidationError("Pipeline metadata 'runtime_inputs' must be a list")
+        available_keys: set[str] = {str(key) for key in runtime_inputs}
 
         for step in pipeline.steps:
             self._validate_step_id(step, seen_ids)

--- a/backend-migration/app/framework/pipeline/runtime_config.py
+++ b/backend-migration/app/framework/pipeline/runtime_config.py
@@ -1,0 +1,25 @@
+"""Runtime pipeline selection helpers (default vs YAML)."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from app.framework.pipeline.defaults import (
+    create_validated_default_pipeline,
+    load_and_validate_pipeline_from_yaml,
+)
+from app.framework.pipeline.types import PipelineDefinition
+
+
+@dataclass(frozen=True)
+class PipelineRuntimeConfig:
+    """Configuration for selecting the active pipeline definition."""
+
+    yaml_path: Optional[str] = None
+
+
+def resolve_pipeline_definition(config: Optional[PipelineRuntimeConfig] = None) -> PipelineDefinition:
+    """Return validated pipeline from config, defaulting to built-in 5-step pipeline."""
+    config = config or PipelineRuntimeConfig()
+    if config.yaml_path:
+        return load_and_validate_pipeline_from_yaml(config.yaml_path)
+    return create_validated_default_pipeline()

--- a/backend-migration/app/framework/pipeline/types.py
+++ b/backend-migration/app/framework/pipeline/types.py
@@ -1,0 +1,24 @@
+"""Core pipeline definition types."""
+
+from dataclasses import dataclass, field
+from typing import Dict, Tuple
+
+
+@dataclass(frozen=True)
+class PipelineStep:
+    """A single pipeline step bound to a function plugin ID."""
+
+    id: str
+    plugin_id: str
+    inputs: Tuple[str, ...] = field(default_factory=tuple)
+    outputs: Tuple[str, ...] = field(default_factory=tuple)
+    config: Dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class PipelineDefinition:
+    """Ordered pipeline definition with optional metadata."""
+
+    id: str
+    steps: Tuple[PipelineStep, ...]
+    metadata: Dict[str, object] = field(default_factory=dict)

--- a/backend-migration/app/framework/pipeline/yaml_loader.py
+++ b/backend-migration/app/framework/pipeline/yaml_loader.py
@@ -1,0 +1,69 @@
+"""Optional YAML loader for pipeline definitions."""
+
+from pathlib import Path
+from typing import Any, Dict, Iterable, Tuple
+
+import yaml
+
+from app.framework.pipeline.types import PipelineDefinition, PipelineStep
+
+
+def _as_tuple_of_strings(value: Any) -> Tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, Iterable) or isinstance(value, (str, bytes)):
+        raise ValueError("Expected a list of strings")
+    result = tuple(str(item) for item in value)
+    return result
+
+
+def _parse_step(raw_step: Dict[str, Any], index: int) -> PipelineStep:
+    if not isinstance(raw_step, dict):
+        raise ValueError(f"Step at index {index} must be an object")
+
+    step_id = str(raw_step.get("id", "")).strip()
+    plugin_id = str(raw_step.get("plugin_id", "")).strip()
+    if not step_id:
+        raise ValueError(f"Step at index {index} is missing 'id'")
+    if not plugin_id:
+        raise ValueError(f"Step '{step_id}' is missing 'plugin_id'")
+
+    config = raw_step.get("config", {})
+    if config is None:
+        config = {}
+    if not isinstance(config, dict):
+        raise ValueError(f"Step '{step_id}' has non-object 'config'")
+
+    return PipelineStep(
+        id=step_id,
+        plugin_id=plugin_id,
+        inputs=_as_tuple_of_strings(raw_step.get("inputs")),
+        outputs=_as_tuple_of_strings(raw_step.get("outputs")),
+        config=config,
+    )
+
+
+def load_pipeline_definition_from_yaml(path: str | Path) -> PipelineDefinition:
+    """Load a `PipelineDefinition` from YAML file."""
+    pipeline_path = Path(path)
+    raw = yaml.safe_load(pipeline_path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError("Pipeline YAML root must be an object")
+
+    pipeline_id = str(raw.get("id", "")).strip()
+    if not pipeline_id:
+        raise ValueError("Pipeline YAML is missing required top-level 'id'")
+
+    raw_steps = raw.get("steps", [])
+    if not isinstance(raw_steps, list):
+        raise ValueError("Pipeline YAML field 'steps' must be a list")
+
+    steps = tuple(_parse_step(step, idx) for idx, step in enumerate(raw_steps))
+
+    metadata = raw.get("metadata", {})
+    if metadata is None:
+        metadata = {}
+    if not isinstance(metadata, dict):
+        raise ValueError("Pipeline YAML field 'metadata' must be an object")
+
+    return PipelineDefinition(id=pipeline_id, steps=steps, metadata=metadata)

--- a/backend-migration/app/framework/schemas/__init__.py
+++ b/backend-migration/app/framework/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""Schema plugin layer."""

--- a/backend-migration/app/framework/schemas/__init__.py
+++ b/backend-migration/app/framework/schemas/__init__.py
@@ -5,6 +5,8 @@ from app.framework.schemas.plugin import (
     SchemaEnrichmentContext,
     SchemaPlugin,
 )
+from app.framework.schemas.default_plugins import MaSMPPlugin, CodeMetaPlugin
+from app.framework.schemas.default_registry import create_default_schema_registry
 from app.framework.schemas.registry import SchemaRegistry
 
 __all__ = [
@@ -12,4 +14,7 @@ __all__ = [
     "SchemaBuildContext",
     "SchemaEnrichmentContext",
     "SchemaRegistry",
+    "MaSMPPlugin",
+    "CodeMetaPlugin",
+    "create_default_schema_registry",
 ]

--- a/backend-migration/app/framework/schemas/__init__.py
+++ b/backend-migration/app/framework/schemas/__init__.py
@@ -1,1 +1,15 @@
 """Schema plugin layer."""
+
+from app.framework.schemas.plugin import (
+    SchemaBuildContext,
+    SchemaEnrichmentContext,
+    SchemaPlugin,
+)
+from app.framework.schemas.registry import SchemaRegistry
+
+__all__ = [
+    "SchemaPlugin",
+    "SchemaBuildContext",
+    "SchemaEnrichmentContext",
+    "SchemaRegistry",
+]

--- a/backend-migration/app/framework/schemas/__init__.py
+++ b/backend-migration/app/framework/schemas/__init__.py
@@ -7,6 +7,7 @@ from app.framework.schemas.plugin import (
 )
 from app.framework.schemas.default_plugins import MaSMPPlugin, CodeMetaPlugin
 from app.framework.schemas.default_registry import create_default_schema_registry
+from app.framework.schemas.resolve import canonical_schema_name, resolve_schema_plugin
 from app.framework.schemas.registry import SchemaRegistry
 
 __all__ = [
@@ -17,4 +18,6 @@ __all__ = [
     "MaSMPPlugin",
     "CodeMetaPlugin",
     "create_default_schema_registry",
+    "resolve_schema_plugin",
+    "canonical_schema_name",
 ]

--- a/backend-migration/app/framework/schemas/default_plugins.py
+++ b/backend-migration/app/framework/schemas/default_plugins.py
@@ -1,0 +1,52 @@
+"""First-party schema plugins that preserve current maSMP/CODEMETA behavior."""
+
+from typing import Any, Dict
+
+from app.adapters.jsonld_builder import JSONLDBuilder
+from app.api.builders.enriched_metadata import build_enriched_metadata
+from app.framework.schemas.plugin import (
+    SchemaBuildContext,
+    SchemaEnrichmentContext,
+    SchemaPlugin,
+)
+
+
+class _BaseBuilderSchemaPlugin:
+    """Shared adapter around the existing JSONLDBuilder implementation."""
+
+    name: str
+    _schema_key: str
+
+    def __init__(self) -> None:
+        self._builder = JSONLDBuilder()
+
+    def validate(self, schema: str) -> bool:
+        return schema.upper() == self._schema_key
+
+    def build_output(self, context: SchemaBuildContext) -> Dict[str, Any]:
+        return self._builder.build_jsonld(
+            metadata=context.metadata,
+            schema=self.name,
+            has_release=context.has_release,
+        )
+
+    def enrich_output(self, context: SchemaEnrichmentContext) -> Dict[str, Any]:
+        return build_enriched_metadata(
+            jsonld_document=context.jsonld_document,
+            extraction_metadata=context.extraction_metadata,
+            schema=self.name,
+        )
+
+
+class MaSMPPlugin(_BaseBuilderSchemaPlugin, SchemaPlugin):
+    """Schema plugin for maSMP outputs."""
+
+    name = "maSMP"
+    _schema_key = "MASMP"
+
+
+class CodeMetaPlugin(_BaseBuilderSchemaPlugin, SchemaPlugin):
+    """Schema plugin for CODEMETA outputs."""
+
+    name = "CODEMETA"
+    _schema_key = "CODEMETA"

--- a/backend-migration/app/framework/schemas/default_registry.py
+++ b/backend-migration/app/framework/schemas/default_registry.py
@@ -1,0 +1,11 @@
+"""Factory for default first-party schema plugin registry."""
+
+from app.framework.schemas.default_plugins import CodeMetaPlugin, MaSMPPlugin
+from app.framework.schemas.registry import SchemaRegistry
+
+
+def create_default_schema_registry() -> SchemaRegistry:
+    """Return registry preloaded with built-in maSMP and CODEMETA plugins."""
+    registry = SchemaRegistry()
+    registry.register_many([MaSMPPlugin(), CodeMetaPlugin()])
+    return registry

--- a/backend-migration/app/framework/schemas/plugin.py
+++ b/backend-migration/app/framework/schemas/plugin.py
@@ -1,0 +1,44 @@
+"""Schema plugin contract and lightweight context objects."""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Protocol
+
+
+@dataclass(frozen=True)
+class SchemaBuildContext:
+    """Inputs needed by schema plugins to build output payloads."""
+
+    metadata: Any
+    has_release: bool
+    raw_schema: str
+
+
+@dataclass(frozen=True)
+class SchemaEnrichmentContext:
+    """Optional enrichment inputs for schema-specific metadata augmentation."""
+
+    jsonld_document: Dict[str, Any]
+    extraction_metadata: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    raw_schema: Optional[str] = None
+
+
+class SchemaPlugin(Protocol):
+    """Contract for schema-specific build and optional enrichment behavior."""
+
+    name: str
+
+    def validate(self, schema: str) -> bool:
+        """Return True if this plugin handles the provided schema identifier."""
+        ...
+
+    def build_output(self, context: SchemaBuildContext) -> Dict[str, Any]:
+        """Build schema-specific output from normalized metadata."""
+        ...
+
+    def enrich_output(self, context: SchemaEnrichmentContext) -> Dict[str, Any]:
+        """
+        Optionally enrich output metadata.
+
+        Implementations may return an empty dictionary when enrichment is not used.
+        """
+        ...

--- a/backend-migration/app/framework/schemas/registry.py
+++ b/backend-migration/app/framework/schemas/registry.py
@@ -1,0 +1,44 @@
+"""In-memory schema plugin registry with explicit registration APIs."""
+
+from typing import Dict, Iterable, Optional
+
+from app.framework.schemas.plugin import SchemaPlugin
+
+
+class SchemaRegistry:
+    """Stores schema plugins and resolves them by schema name."""
+
+    def __init__(self) -> None:
+        self._plugins_by_name: Dict[str, SchemaPlugin] = {}
+
+    def register(self, plugin: SchemaPlugin) -> None:
+        """Register or replace a schema plugin by its name."""
+        self._plugins_by_name[plugin.name.upper()] = plugin
+
+    def register_many(self, plugins: Iterable[SchemaPlugin]) -> None:
+        """Register a collection of plugins."""
+        for plugin in plugins:
+            self.register(plugin)
+
+    def get(self, schema: str) -> Optional[SchemaPlugin]:
+        """Resolve a plugin for a schema, using validate fallback if needed."""
+        key = schema.upper()
+        direct = self._plugins_by_name.get(key)
+        if direct:
+            return direct
+
+        for plugin in self._plugins_by_name.values():
+            if plugin.validate(schema):
+                return plugin
+        return None
+
+    def require(self, schema: str) -> SchemaPlugin:
+        """Resolve a plugin for schema or raise a descriptive error."""
+        plugin = self.get(schema)
+        if not plugin:
+            raise ValueError(f"No schema plugin registered for '{schema}'")
+        return plugin
+
+    def list_names(self) -> list[str]:
+        """Return registered plugin names in stable sorted order."""
+        return sorted(self._plugins_by_name.keys())

--- a/backend-migration/app/framework/schemas/resolve.py
+++ b/backend-migration/app/framework/schemas/resolve.py
@@ -1,0 +1,19 @@
+"""Schema resolution helpers for registry-backed normalization and validation."""
+
+from app.framework.schemas.plugin import SchemaPlugin
+from app.framework.schemas.registry import SchemaRegistry
+
+
+def resolve_schema_plugin(registry: SchemaRegistry, schema: str) -> SchemaPlugin:
+    """
+    Resolve and validate a schema plugin for the provided schema identifier.
+
+    Raises:
+        ValueError: when no plugin is registered for the schema.
+    """
+    return registry.require(schema)
+
+
+def canonical_schema_name(registry: SchemaRegistry, schema: str) -> str:
+    """Return canonical schema name as provided by the resolved plugin."""
+    return resolve_schema_plugin(registry, schema).name

--- a/backend-migration/app/main.py
+++ b/backend-migration/app/main.py
@@ -5,7 +5,7 @@ FastAPI application entry point
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.config.settings import settings
-from app.api.endpoints import metadata
+from app.framework.api import register_default_endpoints
 
 
 app = FastAPI(
@@ -23,8 +23,8 @@ app.add_middleware(
     allow_headers=settings.cors_allow_headers,
 )
 
-# Include routers
-app.include_router(metadata.router)
+# Include routers via framework registrar
+register_default_endpoints(app)
 
 
 @app.get("/")

--- a/backend-migration/app/main.py
+++ b/backend-migration/app/main.py
@@ -5,7 +5,7 @@ FastAPI application entry point
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.config.settings import settings
-from app.framework.api import register_default_endpoints
+from app.framework.api import EndpointRegistrationConfig, register_default_endpoints
 
 
 app = FastAPI(
@@ -24,7 +24,7 @@ app.add_middleware(
 )
 
 # Include routers via framework registrar
-register_default_endpoints(app)
+register_default_endpoints(app, config=EndpointRegistrationConfig.from_env())
 
 
 @app.get("/")

--- a/backend-migration/comet_rs/__init__.py
+++ b/backend-migration/comet_rs/__init__.py
@@ -6,8 +6,9 @@ without exposing internal app.* wiring.
 """
 from typing import Any, Dict, Optional, Tuple, Literal, List
 
-from app.api.services.metadata_service import run_extraction, run_single_property_extraction
-from app.api.services.fairness_service import run_fairness_assessment
+from app.framework.api import extract_metadata as _framework_extract_metadata
+from app.framework.api import extract_property as _framework_extract_property
+from app.framework.api import assess_fairness as _framework_assess_fairness
 from app.core.entities.fairness import FairnessReport
 
 SchemaLiteral = Literal["maSMP", "CODEMETA"]
@@ -26,10 +27,10 @@ def extract_metadata(
     Returns:
         (jsonld_document, enriched_metadata or None)
     """
-    return run_extraction(
+    return _framework_extract_metadata(
         repo_url=repo_url,
         schema=schema,
-        access_token=token,
+        token=token,
         with_enrichment=with_enrichment,
     )
 
@@ -51,11 +52,11 @@ def extract_property(
     SoftwareApplication profiles; all matches are returned. For CODEMETA,
     a single synthetic \"codemeta\" profile is used.
     """
-    extracted_at, items = run_single_property_extraction(
+    extracted_at, items = _framework_extract_property(
         repo_url=repo_url,
-        schema=schema,
-        access_token=token,
         property_name=property_name,
+        schema=schema,
+        token=token,
     )
     return extracted_at, items
 
@@ -72,11 +73,10 @@ def assess_fairness(
     Returns:
         (jsonld_document, FairnessReport)
     """
-    return run_fairness_assessment(
+    return _framework_assess_fairness(
         repo_url=repo_url,
         schema=schema,
-        access_token=token,
-        with_enrichment=False,
+        token=token,
     )
 
 

--- a/backend-migration/scripts/check_pipeline_parity.py
+++ b/backend-migration/scripts/check_pipeline_parity.py
@@ -1,0 +1,85 @@
+"""CLI utility to compare legacy and pipeline extraction outputs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any, Dict
+
+from app.framework.api.metadata_runtime import compare_legacy_and_pipeline_extraction
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Compare legacy and pipeline extraction outputs for parity.",
+    )
+    parser.add_argument("repo_url", help="Repository URL to evaluate")
+    parser.add_argument(
+        "--schema",
+        default="maSMP",
+        choices=["maSMP", "CODEMETA"],
+        help="Schema to extract (default: maSMP)",
+    )
+    parser.add_argument(
+        "--token",
+        default=None,
+        help="Optional platform access token",
+    )
+    parser.add_argument(
+        "--with-enrichment",
+        action="store_true",
+        help="Include enriched metadata parity checks",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print full diagnostics JSON",
+    )
+    return parser
+
+
+def _print_summary(result: Dict[str, Any]) -> None:
+    print(f"schema={result['schema']}")
+    print(f"jsonld_keys_match={result['jsonld_keys_match']}")
+    print(f"jsonld_exact_match={result['jsonld_exact_match']}")
+    print(f"enriched_profiles_match={result['enriched_profiles_match']}")
+    print(f"enriched_exact_match={result['enriched_exact_match']}")
+
+    if result["jsonld_keys_match"] and result["enriched_profiles_match"]:
+        return
+
+    if not result["jsonld_keys_match"]:
+        print("--- legacy_jsonld_keys")
+        print(", ".join(result["legacy_jsonld_keys"]))
+        print("--- pipeline_jsonld_keys")
+        print(", ".join(result["pipeline_jsonld_keys"]))
+
+    if not result["enriched_profiles_match"]:
+        print("--- legacy_enriched_profiles")
+        print(", ".join(result["legacy_enriched_profiles"]))
+        print("--- pipeline_enriched_profiles")
+        print(", ".join(result["pipeline_enriched_profiles"]))
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    result = compare_legacy_and_pipeline_extraction(
+        repo_url=args.repo_url,
+        schema=args.schema,
+        access_token=args.token,
+        with_enrichment=args.with_enrichment,
+    )
+
+    if args.json:
+        print(json.dumps(result, indent=2, default=str))
+    else:
+        _print_summary(result)
+
+    if result["jsonld_exact_match"] and result["enriched_exact_match"]:
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend-migration/tests/test_api_endpoint_env_toggle.py
+++ b/backend-migration/tests/test_api_endpoint_env_toggle.py
@@ -1,0 +1,30 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.framework.api.endpoint_config import EndpointRegistrationConfig
+from app.framework.api.endpoint_registry import register_default_endpoints
+
+
+def test_debug_endpoint_absent_when_debug_group_disabled(monkeypatch):
+    monkeypatch.setenv("COMET_RS_INCLUDE_DEBUG_ENDPOINTS", "0")
+    monkeypatch.setenv("COMET_RS_INCLUDE_METADATA_ENDPOINTS", "1")
+    monkeypatch.setenv("COMET_RS_INCLUDE_SYSTEM_ENDPOINTS", "1")
+
+    app = FastAPI()
+    register_default_endpoints(app, config=EndpointRegistrationConfig.from_env())
+    client = TestClient(app)
+
+    # Debug endpoint group is not registered.
+    debug_response = client.get(
+        "/api/debug/pipeline-parity",
+        params={"repo_url": "https://github.com/example/repo", "schema": "maSMP"},
+    )
+    assert debug_response.status_code == 404
+
+    # Metadata endpoint group remains registered (missing required params => 422).
+    metadata_response = client.get("/api/metadata")
+    assert metadata_response.status_code == 422
+
+    # System endpoint group remains registered and functional.
+    health_response = client.get("/api/health")
+    assert health_response.status_code == 200

--- a/backend-migration/tests/test_api_endpoint_env_toggle.py
+++ b/backend-migration/tests/test_api_endpoint_env_toggle.py
@@ -28,3 +28,21 @@ def test_debug_endpoint_absent_when_debug_group_disabled(monkeypatch):
     # System endpoint group remains registered and functional.
     health_response = client.get("/api/health")
     assert health_response.status_code == 200
+
+
+def test_system_endpoints_absent_when_system_group_disabled(monkeypatch):
+    monkeypatch.setenv("COMET_RS_INCLUDE_DEBUG_ENDPOINTS", "1")
+    monkeypatch.setenv("COMET_RS_INCLUDE_METADATA_ENDPOINTS", "1")
+    monkeypatch.setenv("COMET_RS_INCLUDE_SYSTEM_ENDPOINTS", "0")
+
+    app = FastAPI()
+    register_default_endpoints(app, config=EndpointRegistrationConfig.from_env())
+    client = TestClient(app)
+
+    # System endpoint group is not registered.
+    health_response = client.get("/api/health")
+    assert health_response.status_code == 404
+
+    # Metadata endpoint group remains registered.
+    metadata_response = client.get("/api/metadata")
+    assert metadata_response.status_code == 422

--- a/backend-migration/tests/test_api_endpoint_env_toggle.py
+++ b/backend-migration/tests/test_api_endpoint_env_toggle.py
@@ -46,3 +46,25 @@ def test_system_endpoints_absent_when_system_group_disabled(monkeypatch):
     # Metadata endpoint group remains registered.
     metadata_response = client.get("/api/metadata")
     assert metadata_response.status_code == 422
+
+
+def test_metadata_endpoints_absent_when_metadata_group_disabled(monkeypatch):
+    monkeypatch.setenv("COMET_RS_INCLUDE_DEBUG_ENDPOINTS", "1")
+    monkeypatch.setenv("COMET_RS_INCLUDE_METADATA_ENDPOINTS", "0")
+    monkeypatch.setenv("COMET_RS_INCLUDE_SYSTEM_ENDPOINTS", "1")
+
+    app = FastAPI()
+    register_default_endpoints(app, config=EndpointRegistrationConfig.from_env())
+    client = TestClient(app)
+
+    # Metadata endpoint group is not registered.
+    metadata_response = client.get("/api/metadata")
+    assert metadata_response.status_code == 404
+
+    # System endpoint group remains registered.
+    health_response = client.get("/api/health")
+    assert health_response.status_code == 200
+
+    # Debug route exists (enable flag here), request missing query param leads to validation error.
+    debug_response = client.get("/api/debug/pipeline-parity")
+    assert debug_response.status_code == 422

--- a/backend-migration/tests/test_api_pipeline_parity_endpoint.py
+++ b/backend-migration/tests/test_api_pipeline_parity_endpoint.py
@@ -1,0 +1,62 @@
+from fastapi.testclient import TestClient
+
+from app.api.endpoints import metadata as metadata_endpoints
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def test_pipeline_parity_endpoint_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("COMET_RS_ENABLE_PARITY_ENDPOINT", raising=False)
+
+    response = client.get(
+        "/api/debug/pipeline-parity",
+        params={
+            "repo_url": "https://github.com/example/repo",
+            "schema": "maSMP",
+        },
+    )
+
+    assert response.status_code == 404
+
+
+def test_pipeline_parity_endpoint_enabled_returns_parity(monkeypatch):
+    monkeypatch.setenv("COMET_RS_ENABLE_PARITY_ENDPOINT", "1")
+
+    def fake_compare(repo_url, schema, access_token, with_enrichment):  # type: ignore[no-untyped-def]
+        return {
+            "schema": schema,
+            "jsonld_keys_match": True,
+            "enriched_profiles_match": True,
+            "jsonld_exact_match": True,
+            "enriched_exact_match": True,
+            "legacy_jsonld_keys": ["name"],
+            "pipeline_jsonld_keys": ["name"],
+            "legacy_enriched_profiles": [],
+            "pipeline_enriched_profiles": [],
+            "legacy_jsonld": {"name": "demo"},
+            "pipeline_jsonld": {"name": "demo"},
+            "legacy_enriched": None,
+            "pipeline_enriched": None,
+        }
+
+    monkeypatch.setattr(
+        metadata_endpoints,
+        "compare_legacy_and_pipeline_extraction",
+        fake_compare,
+    )
+
+    response = client.get(
+        "/api/debug/pipeline-parity",
+        params={
+            "repo_url": "https://github.com/example/repo",
+            "schema": "maSMP",
+            "with_enrichment": "false",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "success"
+    assert payload["parity"]["jsonld_exact_match"] is True

--- a/backend-migration/tests/test_api_pipeline_parity_endpoint.py
+++ b/backend-migration/tests/test_api_pipeline_parity_endpoint.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from app.api.endpoints import metadata as metadata_endpoints
+from app.framework.api import debug_router
 from app.main import app
 
 
@@ -42,7 +42,7 @@ def test_pipeline_parity_endpoint_enabled_returns_parity(monkeypatch):
         }
 
     monkeypatch.setattr(
-        metadata_endpoints,
+        debug_router,
         "compare_legacy_and_pipeline_extraction",
         fake_compare,
     )
@@ -87,7 +87,7 @@ def test_pipeline_parity_endpoint_does_not_require_runtime_flag(monkeypatch):
         }
 
     monkeypatch.setattr(
-        metadata_endpoints,
+        debug_router,
         "compare_legacy_and_pipeline_extraction",
         fake_compare,
     )

--- a/backend-migration/tests/test_api_pipeline_parity_endpoint.py
+++ b/backend-migration/tests/test_api_pipeline_parity_endpoint.py
@@ -60,3 +60,45 @@ def test_pipeline_parity_endpoint_enabled_returns_parity(monkeypatch):
     payload = response.json()
     assert payload["status"] == "success"
     assert payload["parity"]["jsonld_exact_match"] is True
+
+
+def test_pipeline_parity_endpoint_does_not_require_runtime_flag(monkeypatch):
+    monkeypatch.setenv("COMET_RS_ENABLE_PARITY_ENDPOINT", "1")
+    monkeypatch.delenv("COMET_RS_USE_PIPELINE_RUNTIME", raising=False)
+
+    calls = {"count": 0}
+
+    def fake_compare(repo_url, schema, access_token, with_enrichment):  # type: ignore[no-untyped-def]
+        calls["count"] += 1
+        return {
+            "schema": schema,
+            "jsonld_keys_match": True,
+            "enriched_profiles_match": True,
+            "jsonld_exact_match": True,
+            "enriched_exact_match": True,
+            "legacy_jsonld_keys": ["name"],
+            "pipeline_jsonld_keys": ["name"],
+            "legacy_enriched_profiles": [],
+            "pipeline_enriched_profiles": [],
+            "legacy_jsonld": {"name": "demo"},
+            "pipeline_jsonld": {"name": "demo"},
+            "legacy_enriched": None,
+            "pipeline_enriched": None,
+        }
+
+    monkeypatch.setattr(
+        metadata_endpoints,
+        "compare_legacy_and_pipeline_extraction",
+        fake_compare,
+    )
+
+    response = client.get(
+        "/api/debug/pipeline-parity",
+        params={
+            "repo_url": "https://github.com/example/repo",
+            "schema": "maSMP",
+        },
+    )
+
+    assert response.status_code == 200
+    assert calls["count"] == 1

--- a/backend-migration/tests/test_api_system_endpoints.py
+++ b/backend-migration/tests/test_api_system_endpoints.py
@@ -1,0 +1,22 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def test_health_endpoint_available():
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "healthy"
+    assert payload["service"] == "metadata-extractor"
+
+
+def test_platforms_endpoint_available():
+    response = client.get("/api/platforms")
+    assert response.status_code == 200
+    payload = response.json()
+    assert "platforms" in payload
+    assert len(payload["platforms"]) >= 2

--- a/backend-migration/tests/test_endpoint_config_env.py
+++ b/backend-migration/tests/test_endpoint_config_env.py
@@ -1,0 +1,23 @@
+from app.framework.api.endpoint_config import EndpointRegistrationConfig
+
+
+def test_endpoint_registration_config_from_env_defaults(monkeypatch):
+    monkeypatch.delenv("COMET_RS_INCLUDE_METADATA_ENDPOINTS", raising=False)
+    monkeypatch.delenv("COMET_RS_INCLUDE_DEBUG_ENDPOINTS", raising=False)
+    monkeypatch.delenv("COMET_RS_INCLUDE_SYSTEM_ENDPOINTS", raising=False)
+
+    config = EndpointRegistrationConfig.from_env()
+    assert config.include_metadata is True
+    assert config.include_debug is True
+    assert config.include_system is True
+
+
+def test_endpoint_registration_config_from_env_overrides(monkeypatch):
+    monkeypatch.setenv("COMET_RS_INCLUDE_METADATA_ENDPOINTS", "true")
+    monkeypatch.setenv("COMET_RS_INCLUDE_DEBUG_ENDPOINTS", "0")
+    monkeypatch.setenv("COMET_RS_INCLUDE_SYSTEM_ENDPOINTS", "no")
+
+    config = EndpointRegistrationConfig.from_env()
+    assert config.include_metadata is True
+    assert config.include_debug is False
+    assert config.include_system is False

--- a/backend-migration/tests/test_endpoint_registry_config.py
+++ b/backend-migration/tests/test_endpoint_registry_config.py
@@ -1,0 +1,38 @@
+from fastapi import FastAPI
+from fastapi.routing import APIRoute
+
+from app.framework.api.endpoint_config import EndpointRegistrationConfig
+from app.framework.api.endpoint_registry import register_default_endpoints
+
+
+def _route_paths(app: FastAPI) -> set[str]:
+    return {
+        route.path
+        for route in app.routes
+        if isinstance(route, APIRoute)
+    }
+
+
+def test_register_default_endpoints_includes_all_by_default():
+    app = FastAPI()
+    register_default_endpoints(app)
+    paths = _route_paths(app)
+    assert "/api/metadata" in paths
+    assert "/api/debug/pipeline-parity" in paths
+    assert "/api/health" in paths
+
+
+def test_register_default_endpoints_can_exclude_debug_and_system():
+    app = FastAPI()
+    register_default_endpoints(
+        app,
+        config=EndpointRegistrationConfig(
+            include_metadata=True,
+            include_debug=False,
+            include_system=False,
+        ),
+    )
+    paths = _route_paths(app)
+    assert "/api/metadata" in paths
+    assert "/api/debug/pipeline-parity" not in paths
+    assert "/api/health" not in paths

--- a/backend-migration/tests/test_pipeline_parity_helper.py
+++ b/backend-migration/tests/test_pipeline_parity_helper.py
@@ -1,0 +1,98 @@
+from app.application.use_cases.extract_metadata import ExtractMetadataResult
+from app.framework.api import metadata_runtime
+
+
+class _StubUseCase:
+    def __init__(self, result: ExtractMetadataResult) -> None:
+        self._result = result
+
+    def execute(self, **kwargs):  # type: ignore[no-untyped-def]
+        return self._result
+
+
+def test_compare_legacy_and_pipeline_extraction_match(monkeypatch):
+    legacy_result = ExtractMetadataResult(
+        jsonld_document={"name": "demo"},
+        extraction_metadata={"name": {"source": "platform", "confidence": 0.9}},
+        metadata=object(),  # not used because _build_jsonld_via_plugin is patched
+    )
+
+    monkeypatch.setattr(
+        metadata_runtime,
+        "canonical_schema_name",
+        lambda registry, schema: schema,
+    )
+    monkeypatch.setattr(
+        metadata_runtime,
+        "create_extraction_use_case",
+        lambda repo_url, access_token, with_enrichment: (_StubUseCase(legacy_result), None),
+    )
+    monkeypatch.setattr(
+        metadata_runtime,
+        "_build_jsonld_via_plugin",
+        lambda metadata, schema, fallback_jsonld: fallback_jsonld,
+    )
+    monkeypatch.setattr(
+        metadata_runtime,
+        "run_extraction_via_pipeline",
+        lambda repo_url, schema, access_token: (
+            {"name": "demo"},
+            {"name": {"source": "platform", "confidence": 0.9}},
+        ),
+    )
+    monkeypatch.setattr(
+        metadata_runtime,
+        "_build_enriched_metadata_via_plugin",
+        lambda jsonld_document, extraction_metadata, schema: {"profile": {"name": {}}},
+    )
+
+    result = metadata_runtime.compare_legacy_and_pipeline_extraction(
+        repo_url="https://example.com/repo",
+        schema="maSMP",
+        access_token=None,
+        with_enrichment=True,
+    )
+
+    assert result["jsonld_keys_match"] is True
+    assert result["enriched_profiles_match"] is True
+    assert result["jsonld_exact_match"] is True
+    assert result["enriched_exact_match"] is True
+
+
+def test_compare_legacy_and_pipeline_extraction_detects_key_mismatch(monkeypatch):
+    legacy_result = ExtractMetadataResult(
+        jsonld_document={"name": "demo"},
+        extraction_metadata={},
+        metadata=object(),
+    )
+
+    monkeypatch.setattr(
+        metadata_runtime,
+        "canonical_schema_name",
+        lambda registry, schema: schema,
+    )
+    monkeypatch.setattr(
+        metadata_runtime,
+        "create_extraction_use_case",
+        lambda repo_url, access_token, with_enrichment: (_StubUseCase(legacy_result), None),
+    )
+    monkeypatch.setattr(
+        metadata_runtime,
+        "_build_jsonld_via_plugin",
+        lambda metadata, schema, fallback_jsonld: fallback_jsonld,
+    )
+    monkeypatch.setattr(
+        metadata_runtime,
+        "run_extraction_via_pipeline",
+        lambda repo_url, schema, access_token: ({"title": "demo"}, {}),
+    )
+
+    result = metadata_runtime.compare_legacy_and_pipeline_extraction(
+        repo_url="https://example.com/repo",
+        schema="maSMP",
+        access_token=None,
+        with_enrichment=False,
+    )
+
+    assert result["jsonld_keys_match"] is False
+    assert result["jsonld_exact_match"] is False

--- a/backend-migration/tests/test_pipeline_runtime_flag.py
+++ b/backend-migration/tests/test_pipeline_runtime_flag.py
@@ -80,3 +80,56 @@ def test_run_extraction_uses_legacy_when_flag_disabled(monkeypatch):
     assert calls["pipeline"] == 0
     assert jsonld_document == {"name": "from-legacy"}
     assert enriched is None
+
+
+def test_run_extraction_with_progress_uses_pipeline_callback_when_flag_enabled(monkeypatch):
+    monkeypatch.setenv("COMET_RS_USE_PIPELINE_RUNTIME", "1")
+    events = []
+
+    def progress_callback(step_id, status):  # type: ignore[no-untyped-def]
+        events.append((step_id, status))
+
+    monkeypatch.setattr(metadata_runtime, "canonical_schema_name", lambda registry, schema: schema)
+
+    def fake_run_extraction_via_pipeline(  # type: ignore[no-untyped-def]
+        repo_url,
+        schema,
+        access_token,
+        progress_callback=None,
+    ):
+        if progress_callback:
+            progress_callback("platform", "started")
+            progress_callback("platform", "completed")
+            progress_callback("jsonld_build", "started")
+            progress_callback("jsonld_build", "completed")
+        return {"name": "from-pipeline"}, {}
+
+    monkeypatch.setattr(
+        metadata_runtime,
+        "run_extraction_via_pipeline",
+        fake_run_extraction_via_pipeline,
+    )
+    monkeypatch.setattr(
+        metadata_runtime,
+        "create_extraction_use_case",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("Legacy path should not be used when pipeline flag is enabled")
+        ),
+    )
+
+    jsonld_document, enriched = metadata_runtime.run_extraction_with_progress(
+        repo_url="https://github.com/example/repo",
+        schema="maSMP",
+        access_token=None,
+        with_enrichment=False,
+        progress_callback=progress_callback,
+    )
+
+    assert jsonld_document == {"name": "from-pipeline"}
+    assert enriched is None
+    assert events == [
+        ("platform", "started"),
+        ("platform", "completed"),
+        ("jsonld_build", "started"),
+        ("jsonld_build", "completed"),
+    ]

--- a/backend-migration/tests/test_pipeline_runtime_flag.py
+++ b/backend-migration/tests/test_pipeline_runtime_flag.py
@@ -1,0 +1,34 @@
+from app.framework.api import metadata_runtime
+
+
+def test_run_extraction_uses_pipeline_when_flag_enabled(monkeypatch):
+    monkeypatch.setenv("COMET_RS_USE_PIPELINE_RUNTIME", "1")
+
+    calls = {"pipeline": 0, "legacy": 0}
+
+    def fake_canonical_schema_name(registry, schema):  # type: ignore[no-untyped-def]
+        return schema
+
+    def fake_run_extraction_via_pipeline(repo_url, schema, access_token, progress_callback=None):  # type: ignore[no-untyped-def]
+        calls["pipeline"] += 1
+        return {"name": "from-pipeline"}, {}
+
+    def fake_create_extraction_use_case(repo_url, access_token, with_enrichment):  # type: ignore[no-untyped-def]
+        calls["legacy"] += 1
+        raise AssertionError("Legacy path should not be used when pipeline flag is enabled")
+
+    monkeypatch.setattr(metadata_runtime, "canonical_schema_name", fake_canonical_schema_name)
+    monkeypatch.setattr(metadata_runtime, "run_extraction_via_pipeline", fake_run_extraction_via_pipeline)
+    monkeypatch.setattr(metadata_runtime, "create_extraction_use_case", fake_create_extraction_use_case)
+
+    jsonld_document, enriched = metadata_runtime.run_extraction(
+        repo_url="https://github.com/example/repo",
+        schema="maSMP",
+        access_token=None,
+        with_enrichment=False,
+    )
+
+    assert calls["pipeline"] == 1
+    assert calls["legacy"] == 0
+    assert jsonld_document == {"name": "from-pipeline"}
+    assert enriched is None

--- a/backend-migration/tests/test_pipeline_runtime_flag.py
+++ b/backend-migration/tests/test_pipeline_runtime_flag.py
@@ -34,8 +34,8 @@ def test_run_extraction_uses_pipeline_when_flag_enabled(monkeypatch):
     assert enriched is None
 
 
-def test_run_extraction_uses_legacy_when_flag_disabled(monkeypatch):
-    monkeypatch.delenv("COMET_RS_USE_PIPELINE_RUNTIME", raising=False)
+def test_run_extraction_uses_legacy_when_flag_forced_off(monkeypatch):
+    monkeypatch.setenv("COMET_RS_USE_PIPELINE_RUNTIME", "0")
 
     calls = {"pipeline": 0, "legacy": 0}
 
@@ -56,7 +56,7 @@ def test_run_extraction_uses_legacy_when_flag_disabled(monkeypatch):
     monkeypatch.setattr(
         metadata_runtime,
         "run_extraction_via_pipeline",
-        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("Pipeline path should not be used when flag is disabled")),
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("Pipeline path should not be used when runtime is forced off")),
     )
     monkeypatch.setattr(
         metadata_runtime,
@@ -79,6 +79,40 @@ def test_run_extraction_uses_legacy_when_flag_disabled(monkeypatch):
     assert calls["legacy"] == 1
     assert calls["pipeline"] == 0
     assert jsonld_document == {"name": "from-legacy"}
+    assert enriched is None
+
+
+def test_run_extraction_defaults_to_pipeline_when_flag_unset(monkeypatch):
+    monkeypatch.delenv("COMET_RS_USE_PIPELINE_RUNTIME", raising=False)
+
+    calls = {"pipeline": 0, "legacy": 0}
+    monkeypatch.setattr(metadata_runtime, "canonical_schema_name", lambda registry, schema: schema)
+    monkeypatch.setattr(
+        metadata_runtime,
+        "run_extraction_via_pipeline",
+        lambda repo_url, schema, access_token, progress_callback=None: (
+            calls.__setitem__("pipeline", calls["pipeline"] + 1) or {"name": "from-pipeline"},
+            {},
+        ),
+    )
+    monkeypatch.setattr(
+        metadata_runtime,
+        "create_extraction_use_case",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("Legacy path should not be used by default")
+        ),
+    )
+
+    jsonld_document, enriched = metadata_runtime.run_extraction(
+        repo_url="https://github.com/example/repo",
+        schema="maSMP",
+        access_token=None,
+        with_enrichment=False,
+    )
+
+    assert calls["pipeline"] == 1
+    assert calls["legacy"] == 0
+    assert jsonld_document == {"name": "from-pipeline"}
     assert enriched is None
 
 

--- a/backend-migration/tests/test_pipeline_runtime_flag.py
+++ b/backend-migration/tests/test_pipeline_runtime_flag.py
@@ -32,3 +32,51 @@ def test_run_extraction_uses_pipeline_when_flag_enabled(monkeypatch):
     assert calls["legacy"] == 0
     assert jsonld_document == {"name": "from-pipeline"}
     assert enriched is None
+
+
+def test_run_extraction_uses_legacy_when_flag_disabled(monkeypatch):
+    monkeypatch.delenv("COMET_RS_USE_PIPELINE_RUNTIME", raising=False)
+
+    calls = {"pipeline": 0, "legacy": 0}
+
+    class _LegacyUseCase:
+        def execute(self, **kwargs):  # type: ignore[no-untyped-def]
+            calls["legacy"] += 1
+            return type(
+                "Result",
+                (),
+                {
+                    "metadata": object(),
+                    "jsonld_document": {"name": "from-legacy"},
+                    "extraction_metadata": {},
+                },
+            )()
+
+    monkeypatch.setattr(metadata_runtime, "canonical_schema_name", lambda registry, schema: schema)
+    monkeypatch.setattr(
+        metadata_runtime,
+        "run_extraction_via_pipeline",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("Pipeline path should not be used when flag is disabled")),
+    )
+    monkeypatch.setattr(
+        metadata_runtime,
+        "create_extraction_use_case",
+        lambda repo_url, access_token, with_enrichment: (_LegacyUseCase(), None),
+    )
+    monkeypatch.setattr(
+        metadata_runtime,
+        "_build_jsonld_via_plugin",
+        lambda metadata, schema, fallback_jsonld: fallback_jsonld,
+    )
+
+    jsonld_document, enriched = metadata_runtime.run_extraction(
+        repo_url="https://github.com/example/repo",
+        schema="maSMP",
+        access_token=None,
+        with_enrichment=False,
+    )
+
+    assert calls["legacy"] == 1
+    assert calls["pipeline"] == 0
+    assert jsonld_document == {"name": "from-legacy"}
+    assert enriched is None


### PR DESCRIPTION
## Summary
This PR migrates metadata extraction to a new framework runtime that is plugin- and pipeline-based, while preserving backward compatibility. It introduces safe rollout controls (feature flags), parity checks between legacy and new paths, and clearer API endpoint registration controls for deployment-specific behavior.

## What Changed?

- Added framework runtime foundations:
  - Function plugin architecture + default extraction stage plugins
  - Schema plugin architecture + default maSMP and CODEMETA plugins
  - Pipeline engine, default 5-step pipeline, runtime pipeline resolution (including YAML support)
- Switched extraction flow to use pipeline runtime by default, with rollback flag:
  - COMET_RS_USE_PIPELINE_RUNTIME=1 (default)
  - COMET_RS_USE_PIPELINE_RUNTIME=0 to force legacy runtime
- Added parity tooling to validate migration safety:
  - CLI utility: scripts/check_pipeline_parity.py
  - Debug endpoint: GET /api/debug/pipeline-parity (disabled unless COMET_RS_ENABLE_PARITY_ENDPOINT=1)
- Refactored API registration into grouped framework routers:
  - Metadata, Debug, and System routers now registered via endpoint registry
  - Env toggles:
    - COMET_RS_INCLUDE_METADATA_ENDPOINTS
    - COMET_RS_INCLUDE_DEBUG_ENDPOINTS
    - COMET_RS_INCLUDE_SYSTEM_ENDPOINTS
- Expanded docs:
  - Custom function plugin guide
  - Custom schema plugin guide
  - Custom pipeline definition guide
- Added focused tests for:
  - Runtime flag behavior
  - Parity helper + parity endpoint behavior
  - Endpoint registration/env toggle behavior
 