### PR TITLE
Fix Dockerfile and Add linkml requirement

### DIFF
--- a/backend-migration/Dockerfile
+++ b/backend-migration/Dockerfile
@@ -1,12 +1,17 @@
-# FastAPI backend (backend-migration)
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
+
+ENV COMET_SCHEMAS_PATH=/app/schemas
 
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/backend-migration/requirements.txt
+++ b/backend-migration/requirements.txt
@@ -12,3 +12,4 @@ ruff>=0.1.6
 mkdocs>=1.6.0
 mkdocs-material>=9.5.0
 scancode-toolkit>=32.5.0
+linkml>=1.11.1


### PR DESCRIPTION
The Docker image was broken because the environment variable was missing and one system requirement (`libgomp`) of a Python module we are using wasn't installed on the base image.